### PR TITLE
fix: change the type of GetContractEnv's 2nd arg from *Cache to Cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/jhump/protoreflect v1.10.3
 	github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6
-	github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a
+	github.com/line/wasmvm v1.0.0-0.10.0.0.20230217123342-3cfcbbfd9cdd
 	github.com/magiconair/properties v1.8.6
 	github.com/mailru/easyjson v0.7.7
 	github.com/mattn/go-isatty v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -645,6 +645,8 @@ github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6 h1:WKz4yaIW+TJgJv5
 github.com/line/ostracon v1.0.7-0.20220729051742-2231684789c6/go.mod h1:8gnHCqwRjbJfhVtQkl7KIfcubtpsIEmiN0u91B4EYWY=
 github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a h1:2wgOMBVR5PObP597P9n/ZkSOUVy3MDjgJH6hR3eqBJE=
 github.com/line/wasmvm v1.0.0-0.10.0.0.20221226034317-6d2861f53d3a/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
+github.com/line/wasmvm v1.0.0-0.10.0.0.20230217123342-3cfcbbfd9cdd h1:DbRslCR2s9w9Bx6+LuR+lUcdIZVyTmGewPIL7TWSorg=
+github.com/line/wasmvm v1.0.0-0.10.0.0.20230217123342-3cfcbbfd9cdd/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/x/wasm/dynamic_link_test.go
+++ b/x/wasm/dynamic_link_test.go
@@ -408,7 +408,7 @@ func TestDynamicCallWithWriteFailsByQuery(t *testing.T) {
 	}
 	queryReq := abci.RequestQuery{Data: []byte(`{"mul":{"value":2}}`)}
 	_, qErr := q(data.ctx, queryPath, queryReq)
-	assert.ErrorContains(t, qErr, "Must not call a writing storage function in this context.")
+	assert.ErrorContains(t, qErr, "Must not call a writing storage / issuing events function in this context.")
 }
 
 // This tests callee_panic in dynamic call fails

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -41,19 +41,16 @@ func (a cosmwasmAPIImpl) canonicalAddress(human string) ([]byte, uint64, error) 
 	return bz, gasMultiplier.ToWasmVMGas(4), err
 }
 
-func (a cosmwasmAPIImpl) getContractEnv(contractAddrStr string, inputSize uint64) (wasmvm.Env, *wasmvm.Cache, wasmvm.KVStore, wasmvm.Querier, wasmvm.GasMeter, []byte, uint64, uint64, error) {
+func (a cosmwasmAPIImpl) getContractEnv(contractAddrStr string, inputSize uint64) (wasmvm.Env, wasmvm.Cache, wasmvm.KVStore, wasmvm.Querier, wasmvm.GasMeter, []byte, uint64, uint64, error) {
 	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
 	contractInfo, codeInfo, prefixStore, err := a.keeper.contractInstance(*a.ctx, contractAddr)
 	if err != nil {
-		return wasmvm.Env{}, nil, nil, nil, nil, wasmvm.Checksum{}, 0, 0, err
+		return wasmvm.Env{}, wasmvm.Cache{}, nil, nil, nil, wasmvm.Checksum{}, 0, 0, err
 	}
 
 	gasMultiplier := a.keeper.getGasMultiplier(*a.ctx)
 
 	cache := a.keeper.wasmVM.GetCache()
-	if cache == nil {
-		panic("cannot found instance cache")
-	}
 
 	// prepare querier
 	querier := NewQueryHandler(*a.ctx, a.keeper.wasmVMQueryHandler, contractAddr, gasMultiplier)

--- a/x/wasm/keeper/api_test.go
+++ b/x/wasm/keeper/api_test.go
@@ -94,7 +94,7 @@ func TestAPIGetContractEnv(t *testing.T) {
 		assert.Equal(t, ctx.ChainID(), env.Block.ChainID)
 		assert.Equal(t, contractAddr.String(), env.Contract.Address)
 
-		code, err := wasmvmapi.GetCode(*cache, hash)
+		code, err := wasmvmapi.GetCode(cache, hash)
 		assert.Equal(t, numberWasm, code)
 
 		// "number" comes from https://github.com/line/cosmwasm/blob/d08b5a59115cc3d28f375b7425b902bfd1dac6a4/contracts/number/src/contract.rs#L9

--- a/x/wasm/keeper/wasmtesting/mock_engine.go
+++ b/x/wasm/keeper/wasmtesting/mock_engine.go
@@ -36,7 +36,7 @@ type MockWasmer struct {
 	PinFn               func(checksum wasmvm.Checksum) error
 	UnpinFn             func(checksum wasmvm.Checksum) error
 	GetMetricsFn        func() (*wasmvmtypes.Metrics, error)
-	GetCacheFn          func() *wasmvm.Cache
+	GetCacheFn          func() wasmvm.Cache
 }
 
 func (m *MockWasmer) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBC3ChannelOpenResponse, uint64, error) {
@@ -173,7 +173,7 @@ func (m *MockWasmer) GetMetrics() (*wasmvmtypes.Metrics, error) {
 	return m.GetMetricsFn()
 }
 
-func (m *MockWasmer) GetCache() *wasmvm.Cache {
+func (m *MockWasmer) GetCache() wasmvm.Cache {
 	if m.GetCacheFn == nil {
 		panic("not expected to be called")
 	}

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -240,5 +240,5 @@ type WasmerEngine interface {
 	// GetMetrics some internal metrics for monitoring purposes.
 	GetMetrics() (*wasmvmtypes.Metrics, error)
 
-	GetCache() *wasmvm.Cache
+	GetCache() wasmvm.Cache
 }


### PR DESCRIPTION
This PR changes the type of the `GetContractEnv`'s 2nd arg from `*Cache` to `Cache`.

An un-merged version of wasmvm is referenced in this PR. This is replaced after it is merged.

## Description
<!--- Describe your changes in detail -->
closes: https://github.com/line/wasmvm/issues/90

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see https://github.com/line/wasmvm/issues/90 for detail.

## How has this been tested?
Existing unit tests 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes. (Not needed)
- [ ] I have updated the documentation accordingly. (Not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (Not needed)
