### PR TITLE
fix: not to throw error when no txs in block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#960](https://github.com/Finschia/finschia-sdk/pull/960) Fix default next class ids of x/collection
 * (x/collection) [\#961](https://github.com/Finschia/finschia-sdk/pull/961) Do not loop enum in x/collection
 * (x/collection,token) [\#957](https://github.com/Finschia/finschia-sdk/pull/957) Refactor queries of x/collection and x/token
+* (x/auth) [\#957](https://github.com/line/lbm-sdk/pull/957) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
 
 ### Removed
 * (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection) [\#960](https://github.com/Finschia/finschia-sdk/pull/960) Fix default next class ids of x/collection
 * (x/collection) [\#961](https://github.com/Finschia/finschia-sdk/pull/961) Do not loop enum in x/collection
 * (x/collection,token) [\#957](https://github.com/Finschia/finschia-sdk/pull/957) Refactor queries of x/collection and x/token
-* (x/auth) [\#957](https://github.com/line/lbm-sdk/pull/957) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
+* (x/auth) [\#982](https://github.com/Finschia/finschia-sdk/pull/957) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
 
 ### Removed
 * (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token

--- a/x/auth/tx2/service.go
+++ b/x/auth/tx2/service.go
@@ -69,7 +69,7 @@ func (s tx2Server) GetBlockWithTxs(ctx context.Context, req *tx2types.GetBlockWi
 	blockTxs := block.Data.Txs
 	blockTxsLn := uint64(len(blockTxs))
 	txs := make([]*txtypes.Tx, 0, limit)
-	if offset >= blockTxsLn {
+	if offset >= blockTxsLn && blockTxsLn != 0 {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("out of range: cannot paginate %d txs with offset %d and limit %d", blockTxsLn, offset, limit)
 	}
 	decodeTxAt := func(i uint64) error {

--- a/x/auth/tx2/service_test.go
+++ b/x/auth/tx2/service_test.go
@@ -99,14 +99,16 @@ func (s IntegrationTestSuite) TestGetBlockWithTxs_GRPC() {
 		req       *tx2.GetBlockWithTxsRequest
 		expErr    bool
 		expErrMsg string
+		expTxsLen int
 	}{
-		{"nil request", nil, true, "request cannot be nil"},
-		{"empty request", &tx2.GetBlockWithTxsRequest{}, true, "height must not be less than 1 or greater than the current height"},
-		{"bad height", &tx2.GetBlockWithTxsRequest{Height: 99999999}, true, "height must not be less than 1 or greater than the current height"},
-		{"bad pagination", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 1000, Limit: 100}}, true, "out of range"},
-		{"good request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight}, false, ""},
-		{"with pagination request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 0, Limit: 1}}, false, ""},
-		{"page all request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 0, Limit: 100}}, false, ""},
+		{"nil request", nil, true, "request cannot be nil", 0},
+		{"empty request", &tx2.GetBlockWithTxsRequest{}, true, "height must not be less than 1 or greater than the current height", 0},
+		{"bad height", &tx2.GetBlockWithTxsRequest{Height: 99999999}, true, "height must not be less than 1 or greater than the current height", 0},
+		{"bad pagination", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 1000, Limit: 100}}, true, "out of range", 0},
+		{"good request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight}, false, "", 1},
+		{"with pagination request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 0, Limit: 1}}, false, "", 1},
+		{"page all request", &tx2.GetBlockWithTxsRequest{Height: s.txHeight, Pagination: &query.PageRequest{Offset: 0, Limit: 100}}, false, "", 1},
+		{"block with 0 tx", &tx2.GetBlockWithTxsRequest{Height: s.txHeight - 1, Pagination: &query.PageRequest{Offset: 0, Limit: 100}}, false, "", 0},
 	}
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
@@ -117,7 +119,9 @@ func (s IntegrationTestSuite) TestGetBlockWithTxs_GRPC() {
 				s.Require().Contains(err.Error(), tc.expErrMsg)
 			} else {
 				s.Require().NoError(err)
-				s.Require().Equal("foobar", grpcRes.Txs[0].Body.Memo)
+				if tc.expTxsLen > 0 {
+					s.Require().Equal("foobar", grpcRes.Txs[0].Body.Memo)
+				}
 				s.Require().Equal(grpcRes.Block.Header.Height, tc.req.Height)
 				if tc.req.Pagination != nil {
 					s.Require().LessOrEqual(len(grpcRes.Txs), int(tc.req.Pagination.Limit))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I followd this [cosmos-sdk/issues/12040](https://github.com/cosmos/cosmos-sdk/issues/12040) and [cosmos-sdk/pull/12108](https://github.com/cosmos/cosmos-sdk/pull/12108)

our version 0.45.x does not have `GetBlockWithTxs` in `x/auth/tx/service`, so we create `x/auth/tx2`.
It's hard to cherr-pick because the directories are different. So I reflected the changes directly into tx2.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When query through `GetBlockWithTxs`, `invalid request` error occurred when no txs are included in block.
The correct behavior is to return the block with empty list of txs.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested no error occured and return 0 length of tx list

## Screenshots (if appropriate):
before thsi PR, when tx does not exist in block
```
{
  "code": 3,
  "message": "out of range: cannot paginate 0 txs with offset 0 and limit 100: invalid request: invalid request",
  "details": []
}
```

when tx does not exist in block
```
{
  "txs": [],
  "block_id": {
    "hash": "tMvoEOdixC8Kt9YNwb6vGDsYJO/euSW3TRuDfzLijPk=",
    "part_set_header": {
      "total": 1,
      "hash": "ykh4pBbXq5ehsj2zyFRv0UdOFnf/8rVwjVl5MXN+pFM="
    }
  },
  "block": {
    "header": {
      "version": {
        "block": "11",
        "app": "0"
      },
      "chain_id": "simd-testing",
      "height": "115",
      "time": "2023-04-18T08:51:57.136998Z",
      "last_block_id": {
        "hash": "2mVthS8/78uoXxmNaQaO43UivRU142JD42xE/d3ps4I=",
        "part_set_header": {
          "total": 1,
          "hash": "ucOMMUTAhQtMR8sREYbbyG6RKKIDb3bOxjh5D/j1s0M="
        }
      },
      "last_commit_hash": "sUmrUkJM+xlOfckEN7yXVJX9zFySepZa2Gnl670tzwQ=",
      "data_hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
      "validators_hash": "wUFwitwdiD2JQIkDe4MofWg7YqGlxwofCZBWzI7H5Mk=",
      "next_validators_hash": "wUFwitwdiD2JQIkDe4MofWg7YqGlxwofCZBWzI7H5Mk=",
      "consensus_hash": "BICRvH3cKD93v7+R1zxE2ljD34qcvIZ0Bdi389qtoi8=",
      "app_hash": "39H866EPWyvnODRPEYFHFVXqdH+EJj03QpKADY12BGI=",
      "last_results_hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
      "evidence_hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
      "proposer_address": "VwWa2x8sslGSe+6MjgugQo0iGBA="
    },
    "data": {
      "txs": []
    },
    "evidence": {
      "evidence": []
    },
    "last_commit": {
      "height": "114",
      "round": 0,
      "block_id": {
        "hash": "2mVthS8/78uoXxmNaQaO43UivRU142JD42xE/d3ps4I=",
        "part_set_header": {
          "total": 1,
          "hash": "ucOMMUTAhQtMR8sREYbbyG6RKKIDb3bOxjh5D/j1s0M="
        }
      },
      "signatures": [
        {
          "block_id_flag": "BLOCK_ID_FLAG_COMMIT",
          "validator_address": "VwWa2x8sslGSe+6MjgugQo0iGBA=",
          "timestamp": "2023-04-18T08:51:57.136998Z",
          "signature": "lsvVrOiJqC8HzBR98fExYb32m4a+Hx2BtpeS8xu98EArSt7xM9Fni55jNujet85uWczriUFhUdPOf2zDEGyRBQ=="
        }
      ]
    },
    "entropy": {
      "round": 0,
      "proof": "A1AeRTirM3lC5QXH0DaCevHadrGw5WTRwOkOMytT5rDqUG19978T9wGAoR94pYQBYQ2DIHCI5QzyYAwTB6P8hqfULXBvsb8FAxvCKfjO6yQK"
    }
  },
  "pagination": {
    "next_key": null,
    "total": "0"
  }
}
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
