### PR TITLE
Release finschia-sdk v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,48 +35,19 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [Unreleased](https://github.com/Finschia/finschia-sdk/compare/v0.47.0-alpha1...HEAD)
+## [Unreleased](https://github.com/Finschia/finschia-sdk/compare/v0.47.0...HEAD)
 
 ### Features
-* (all) [\#970](https://github.com/Finschia/finschia-sdk/pull/970) change import path to `github.com/Finschia/finschia-sdk` and update license
 
 ### Improvements
-* (x/collection,token) [\#900](https://github.com/Finschia/finschia-sdk/pull/900) Add uri for MsgModify and deprecate the old ones
-* (x/foundation) [\#912](https://github.com/Finschia/finschia-sdk/pull/912) Introduce censorship into x/foundation
-* (x/foundation) [\#933](https://github.com/Finschia/finschia-sdk/pull/933) Clean up x/foundation apis
-* (x/collection) [\#938](https://github.com/Finschia/finschia-sdk/pull/938) Add progress log into x/collection import-genesis
-* (x/foundation) [\#952](https://github.com/Finschia/finschia-sdk/pull/952) Address generation of the empty coins in x/foundation
-* (x/collection,token,foundation) [\#963](https://github.com/Finschia/finschia-sdk/pull/963) Check event determinism on original modules
-* (x/collection) [\#965](https://github.com/Finschia/finschia-sdk/pull/965) Provide specific error messages on x/collection queries
-* (x/collection,token) [\#980](https://github.com/Finschia/finschia-sdk/pull/980) refactor x/token,collection query errors
 
 ### Bug Fixes
-* (swagger) [\#898](https://github.com/Finschia/finschia-sdk/pull/898) fix a bug not added `lbm.tx.v1beta1.Service/GetBlockWithTxs` in swagger
-* (x/collection) [\#911](https://github.com/Finschia/finschia-sdk/pull/911) Add missing command(TxCmdModify) for CLI
-* (x/foundation) [\#922](https://github.com/Finschia/finschia-sdk/pull/922) Propagate events in x/foundation through sdk.Results
-* (x/foundation) [\#946](https://github.com/Finschia/finschia-sdk/pull/946) Fix broken x/foundation invariant on treasury
-* (x/foundation) [\#947](https://github.com/Finschia/finschia-sdk/pull/947) Unpack proposals in x/foundation import-genesis
-* (x/collection) [\#953](https://github.com/Finschia/finschia-sdk/pull/953) Allow zero amount of coin in x/collection Query/Balance
-* (x/collection) [\#954](https://github.com/Finschia/finschia-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
-* (x/collection) [\#955](https://github.com/Finschia/finschia-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
-* (x/collection) [\#959](https://github.com/Finschia/finschia-sdk/pull/959) Revert #955 and add Query/HasParent into x/collection
-* (x/collection) [\#960](https://github.com/Finschia/finschia-sdk/pull/960) Fix default next class ids of x/collection
-* (x/collection) [\#961](https://github.com/Finschia/finschia-sdk/pull/961) Do not loop enum in x/collection
-* (x/collection,token) [\#957](https://github.com/Finschia/finschia-sdk/pull/957) Refactor queries of x/collection and x/token
-* (x/auth) [\#982](https://github.com/Finschia/finschia-sdk/pull/957) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
-* (x/foundation) [\#984](https://github.com/Finschia/finschia-sdk/pull/984) Revert #952
 
 ### Removed
-* (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token
 
 ### Breaking Changes
-* (proto) [\#923](https://github.com/Finschia/finschia-sdk/pull/923) deprecate broadcast mode `block`
-* (x/collection,token) [\#956](https://github.com/Finschia/finschia-sdk/pull/956) Replace query errors on the original modules into gRPC ones
 
 ### Build, CI
-* (ci, build) [\#901](https://github.com/Finschia/finschia-sdk/pull/901) Update release pipeline to match non-wasm env
-* (ci) [\#983](https://github.com/Finschia/finschia-sdk/pull/983) update docker action to fit new repository
 
 ### Document Updates
-* (x/foundation) [\#934](https://github.com/Finschia/finschia-sdk/pull/934) Update permlinks in x/foundation documents
-* (x/collection,token) [\#944](https://github.com/Finschia/finschia-sdk/pull/944) Update comments in the x/token,collection events proto
+

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.47.0-alpha1](https://github.com/Finschia/finschia-sdk/releases/tag/v0.47.0-alpha1) - 2023-02-13
+## [v0.47.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.47.0) - 2023-04-24
 
 ### Features
 * (baseapp) [\#840](https://github.com/Finschia/finschia-sdk/pull/840) allow querying the state based on `CheckState`.
@@ -9,6 +9,7 @@
 * (log) [\#883](https://github.com/Finschia/finschia-sdk/pull/883) add zerolog based rolling log system
 * (Ostracon) [\#887](https://github.com/Finschia/finschia-sdk/pull/887) apply the changes of vrf location in Ostracon
 * (x/upgrade) [\#889](https://github.com/Finschia/finschia-sdk/pull/889) remove time based upgrade
+* (all) [\#970](https://github.com/Finschia/finschia-sdk/pull/970) change import path to `github.com/Finschia/finschia-sdk` and update license
 
 ### Improvements
 * (cosmovisor) [\#792](https://github.com/Finschia/finschia-sdk/pull/792) Use upstream's cosmovisor
@@ -16,6 +17,14 @@
 * (client) [\#890](https://github.com/Finschia/finschia-sdk/pull/890) Map Ostracon:ErrTxInMap to lbm-sdk:ErrTxInMempoolCache
 * (x/collection) [\#894](https://github.com/Finschia/finschia-sdk/pull/894) Change the default params of x/collection
 * (ante) [\#895](https://github.com/Finschia/finschia-sdk/pull/895) Remove max gas validation
+* (x/collection,token) [\#900](https://github.com/Finschia/finschia-sdk/pull/900) Add uri for MsgModify and deprecate the old ones
+* (x/foundation) [\#912](https://github.com/Finschia/finschia-sdk/pull/912) Introduce censorship into x/foundation
+* (x/foundation) [\#933](https://github.com/Finschia/finschia-sdk/pull/933) Clean up x/foundation apis
+* (x/collection) [\#938](https://github.com/Finschia/finschia-sdk/pull/938) Add progress log into x/collection import-genesis
+* (x/foundation) [\#952](https://github.com/Finschia/finschia-sdk/pull/952) Address generation of the empty coins in x/foundation
+* (x/collection,token,foundation) [\#963](https://github.com/Finschia/finschia-sdk/pull/963) Check event determinism on original modules
+* (x/collection) [\#965](https://github.com/Finschia/finschia-sdk/pull/965) Provide specific error messages on x/collection queries
+* (x/collection,token) [\#980](https://github.com/Finschia/finschia-sdk/pull/980) refactor x/token,collection query errors
 
 ### Bug Fixes
 * (client) [\#817](https://github.com/Finschia/finschia-sdk/pull/817) remove support for composite (BLS) type
@@ -24,11 +33,26 @@
 * (x/token,collection) [\#863](https://github.com/Finschia/finschia-sdk/pull/863) Update x/collection,token proto
 * (x/collection,token) [\#866](https://github.com/Finschia/finschia-sdk/pull/866) Do not create account on x/token,collection
 * (x/collection,token) [\#881](https://github.com/Finschia/finschia-sdk/pull/881) Remove some x/token,collection queries on listable collections
+* (swagger) [\#898](https://github.com/Finschia/finschia-sdk/pull/898) fix a bug not added `lbm.tx.v1beta1.Service/GetBlockWithTxs` in swagger
+* (x/collection) [\#911](https://github.com/Finschia/finschia-sdk/pull/911) Add missing command(TxCmdModify) for CLI
+* (x/foundation) [\#922](https://github.com/Finschia/finschia-sdk/pull/922) Propagate events in x/foundation through sdk.Results
+* (x/foundation) [\#946](https://github.com/Finschia/finschia-sdk/pull/946) Fix broken x/foundation invariant on treasury
+* (x/foundation) [\#947](https://github.com/Finschia/finschia-sdk/pull/947) Unpack proposals in x/foundation import-genesis
+* (x/collection) [\#953](https://github.com/Finschia/finschia-sdk/pull/953) Allow zero amount of coin in x/collection Query/Balance
+* (x/collection) [\#954](https://github.com/Finschia/finschia-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
+* (x/collection) [\#955](https://github.com/Finschia/finschia-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
+* (x/collection) [\#959](https://github.com/Finschia/finschia-sdk/pull/959) Revert #955 and add Query/HasParent into x/collection
+* (x/collection) [\#960](https://github.com/Finschia/finschia-sdk/pull/960) Fix default next class ids of x/collection
+* (x/collection) [\#961](https://github.com/Finschia/finschia-sdk/pull/961) Do not loop enum in x/collection
+* (x/collection,token) [\#957](https://github.com/Finschia/finschia-sdk/pull/957) Refactor queries of x/collection and x/token
+* (x/auth) [\#982](https://github.com/Finschia/finschia-sdk/pull/982) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
+* (x/foundation) [\#984](https://github.com/Finschia/finschia-sdk/pull/984) Revert #952
 
 ### Removed
 * [\#853](https://github.com/Finschia/finschia-sdk/pull/853) remove useless stub BeginBlock, EndBlock methods from modules below
   * ibc, authz, collection, feegrant, ibc, token, wasm
 * (x/ibc) [\#858](https://github.com/Finschia/finschia-sdk/pull/858) detach ibc module(repo: [line/ibc-go](https://github.com/Finschia/ibc-go))
+* (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token
 
 ### Breaking Changes
 * (rest) [\#807](https://github.com/Finschia/finschia-sdk/pull/807) remove legacy REST API
@@ -37,10 +61,18 @@
 * (x/bank) [\#876](https://github.com/Finschia/finschia-sdk/pull/876) Add `MultiSend` deactivation
 * (x/auth) [\#891](https://github.com/Finschia/finschia-sdk/pull/891) deprecate `cosmos.tx.v1beta1.Service/GetBlockWithTxs` and add `lbm.tx.v1beta1.Service/GetBlockWithTxs` for lbm
 * (abci) [\#892](https://github.com/Finschia/finschia-sdk/pull/892) remove the incompatible field `index=14` in `TxResponse`
+* (proto) [\#923](https://github.com/Finschia/finschia-sdk/pull/923) deprecate broadcast mode `block`
+* (x/collection,token) [\#956](https://github.com/Finschia/finschia-sdk/pull/956) Replace query errors on the original modules into gRPC ones
 
 ### Build, CI
 * (ci) [\#829](https://github.com/Finschia/finschia-sdk/pull/829) automate release process
 * (build) [\#872](https://github.com/Finschia/finschia-sdk/pull/872) Retract v1.0.0
+* (ci, build) [\#901](https://github.com/Finschia/finschia-sdk/pull/901) Update release pipeline to match non-wasm env
+* (ci) [\#983](https://github.com/Finschia/finschia-sdk/pull/983) update docker action to fit new repository
+
+### Document Updates
+* (x/foundation) [\#934](https://github.com/Finschia/finschia-sdk/pull/934) Update permlinks in x/foundation documents
+* (x/collection,token) [\#944](https://github.com/Finschia/finschia-sdk/pull/944) Update comments in the x/token,collection events proto
 
 
 ## [v0.46.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.46.0) - 2022-11-28

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -51,7 +51,7 @@
 ### Removed
 * [\#853](https://github.com/Finschia/finschia-sdk/pull/853) remove useless stub BeginBlock, EndBlock methods from modules below
   * ibc, authz, collection, feegrant, ibc, token, wasm
-* (x/ibc) [\#858](https://github.com/Finschia/finschia-sdk/pull/858) detach ibc module(repo: [line/ibc-go](https://github.com/Finschia/ibc-go))
+* (x/ibc) [\#858](https://github.com/Finschia/finschia-sdk/pull/858) detach ibc module(repo: [finschia/ibc-go](https://github.com/Finschia/ibc-go))
 * (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token
 
 ### Breaking Changes

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/Finschia/finschia-sdk
 
 require (
 	github.com/99designs/keyring v1.1.6
-	github.com/Finschia/ostracon v1.0.10-0.20230417071658-1c9c22cfe90d
+	github.com/Finschia/ostracon v1.1.0
 	github.com/VictoriaMetrics/fastcache v1.12.0
 	github.com/armon/go-metrics v0.4.1
 	github.com/bgentry/speakeasy v0.1.0
@@ -108,8 +108,8 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/r2ishiguro/vrf v0.0.0-20180716233122-192de52975eb // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
-	github.com/rs/cors v1.8.3 // indirect
-	github.com/rs/zerolog v1.29.0 // indirect
+	github.com/rs/cors v1.9.0 // indirect
+	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/Finschia/ostracon v1.0.10-0.20230417071658-1c9c22cfe90d h1:1BP8Gnz5vi39c8n/Gv0ZsUy0XMQ0cKf68nxZKVFr3Hg=
-github.com/Finschia/ostracon v1.0.10-0.20230417071658-1c9c22cfe90d/go.mod h1:nlWnrD4DEhWbWuHJcadv2Rh3zQr9MCeYZMfXrln9G6k=
+github.com/Finschia/ostracon v1.1.0 h1:ruiqngsoCz1kJ3fGLJHflcvxbJrbg7QGDTruqxgLZKc=
+github.com/Finschia/ostracon v1.1.0/go.mod h1:nPRoQEOOp8FFp2XQ8b1dvfHgKNxp1Zb7i1p5yrLIgG4=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.1.0/go.mod h1:LGOGuvEgCfCQsy3JF2tRmpGDpzA53iZfyGEWSPwQ6/4=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
@@ -231,6 +231,7 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
@@ -1022,13 +1023,13 @@ github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XF
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
-github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
+github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
-github.com/rs/zerolog v1.29.0 h1:Zes4hju04hjbvkVkOhdl2HpZa+0PmVwigmo8XoORE5w=
-github.com/rs/zerolog v1.29.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
+github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
## Release v0.47.0 

### Features
* (baseapp) [\#840](https://github.com/Finschia/finschia-sdk/pull/840) allow querying the state based on `CheckState`.
* (x/foundation) [\#848](https://github.com/Finschia/finschia-sdk/pull/848) remove `gov mint` for x/foundation proposal
* (x/wasm) [\#850](https://github.com/Finschia/finschia-sdk/pull/850) remove `x/wasm` module in lbm-sdk
* (log) [\#883](https://github.com/Finschia/finschia-sdk/pull/883) add zerolog based rolling log system
* (Ostracon) [\#887](https://github.com/Finschia/finschia-sdk/pull/887) apply the changes of vrf location in Ostracon
* (x/upgrade) [\#889](https://github.com/Finschia/finschia-sdk/pull/889) remove time based upgrade
* (all) [\#970](https://github.com/Finschia/finschia-sdk/pull/970) change import path to `github.com/Finschia/finschia-sdk` and update license

### Improvements
* (cosmovisor) [\#792](https://github.com/Finschia/finschia-sdk/pull/792) Use upstream's cosmovisor
* (server) [\#821](https://github.com/Finschia/finschia-sdk/pull/821) Get validator pubkey considering KMS
* (client) [\#890](https://github.com/Finschia/finschia-sdk/pull/890) Map Ostracon:ErrTxInMap to lbm-sdk:ErrTxInMempoolCache
* (x/collection) [\#894](https://github.com/Finschia/finschia-sdk/pull/894) Change the default params of x/collection
* (ante) [\#895](https://github.com/Finschia/finschia-sdk/pull/895) Remove max gas validation
* (x/collection,token) [\#900](https://github.com/Finschia/finschia-sdk/pull/900) Add uri for MsgModify and deprecate the old ones
* (x/foundation) [\#912](https://github.com/Finschia/finschia-sdk/pull/912) Introduce censorship into x/foundation
* (x/foundation) [\#933](https://github.com/Finschia/finschia-sdk/pull/933) Clean up x/foundation apis
* (x/collection) [\#938](https://github.com/Finschia/finschia-sdk/pull/938) Add progress log into x/collection import-genesis
* (x/foundation) [\#952](https://github.com/Finschia/finschia-sdk/pull/952) Address generation of the empty coins in x/foundation
* (x/collection,token,foundation) [\#963](https://github.com/Finschia/finschia-sdk/pull/963) Check event determinism on original modules
* (x/collection) [\#965](https://github.com/Finschia/finschia-sdk/pull/965) Provide specific error messages on x/collection queries
* (x/collection,token) [\#980](https://github.com/Finschia/finschia-sdk/pull/980) refactor x/token,collection query errors

### Bug Fixes
* (client) [\#817](https://github.com/Finschia/finschia-sdk/pull/817) remove support for composite (BLS) type
* (x/foundation) [\#834](https://github.com/Finschia/finschia-sdk/pull/834) Apply foundation audit
* (x/collection,token) [\#849](https://github.com/Finschia/finschia-sdk/pull/849) Introduce codespace into x/collection,token
* (x/token,collection) [\#863](https://github.com/Finschia/finschia-sdk/pull/863) Update x/collection,token proto
* (x/collection,token) [\#866](https://github.com/Finschia/finschia-sdk/pull/866) Do not create account on x/token,collection
* (x/collection,token) [\#881](https://github.com/Finschia/finschia-sdk/pull/881) Remove some x/token,collection queries on listable collections
* (swagger) [\#898](https://github.com/Finschia/finschia-sdk/pull/898) fix a bug not added `lbm.tx.v1beta1.Service/GetBlockWithTxs` in swagger
* (x/collection) [\#911](https://github.com/Finschia/finschia-sdk/pull/911) Add missing command(TxCmdModify) for CLI
* (x/foundation) [\#922](https://github.com/Finschia/finschia-sdk/pull/922) Propagate events in x/foundation through sdk.Results
* (x/foundation) [\#946](https://github.com/Finschia/finschia-sdk/pull/946) Fix broken x/foundation invariant on treasury
* (x/foundation) [\#947](https://github.com/Finschia/finschia-sdk/pull/947) Unpack proposals in x/foundation import-genesis
* (x/collection) [\#953](https://github.com/Finschia/finschia-sdk/pull/953) Allow zero amount of coin in x/collection Query/Balance
* (x/collection) [\#954](https://github.com/Finschia/finschia-sdk/pull/954) Remove duplicated events in x/collection Msg/Modify
* (x/collection) [\#955](https://github.com/Finschia/finschia-sdk/pull/955) Return nil where the parent not exists in x/collection Query/Parent
* (x/collection) [\#959](https://github.com/Finschia/finschia-sdk/pull/959) Revert #955 and add Query/HasParent into x/collection
* (x/collection) [\#960](https://github.com/Finschia/finschia-sdk/pull/960) Fix default next class ids of x/collection
* (x/collection) [\#961](https://github.com/Finschia/finschia-sdk/pull/961) Do not loop enum in x/collection
* (x/collection,token) [\#957](https://github.com/Finschia/finschia-sdk/pull/957) Refactor queries of x/collection and x/token
* (x/auth) [\#982](https://github.com/Finschia/finschia-sdk/pull/982) Fix not to emit error when no txs in block while querying `GetBlockWithTxs`
* (x/foundation) [\#984](https://github.com/Finschia/finschia-sdk/pull/984) Revert #952

### Removed
* [\#853](https://github.com/Finschia/finschia-sdk/pull/853) remove useless stub BeginBlock, EndBlock methods from modules below
  * ibc, authz, collection, feegrant, ibc, token, wasm
* (x/ibc) [\#858](https://github.com/Finschia/finschia-sdk/pull/858) detach ibc module(repo: [line/ibc-go](https://github.com/Finschia/ibc-go))
* (x/collection,token) [\#966](https://github.com/Finschia/finschia-sdk/pull/966) Remove legacy events on x/collection and x/token

### Breaking Changes
* (rest) [\#807](https://github.com/Finschia/finschia-sdk/pull/807) remove legacy REST API
* (codec) [\#833](https://github.com/Finschia/finschia-sdk/pull/833) Fix foundation amino codec
* (ostracon) [\#869](https://github.com/Finschia/finschia-sdk/pull/869) apply changes to replace Ostracon proto message with Tendermint
* (x/bank) [\#876](https://github.com/Finschia/finschia-sdk/pull/876) Add `MultiSend` deactivation
* (x/auth) [\#891](https://github.com/Finschia/finschia-sdk/pull/891) deprecate `cosmos.tx.v1beta1.Service/GetBlockWithTxs` and add `lbm.tx.v1beta1.Service/GetBlockWithTxs` for lbm
* (abci) [\#892](https://github.com/Finschia/finschia-sdk/pull/892) remove the incompatible field `index=14` in `TxResponse`
* (proto) [\#923](https://github.com/Finschia/finschia-sdk/pull/923) deprecate broadcast mode `block`
* (x/collection,token) [\#956](https://github.com/Finschia/finschia-sdk/pull/956) Replace query errors on the original modules into gRPC ones

### Build, CI
* (ci) [\#829](https://github.com/Finschia/finschia-sdk/pull/829) automate release process
* (build) [\#872](https://github.com/Finschia/finschia-sdk/pull/872) Retract v1.0.0
* (ci, build) [\#901](https://github.com/Finschia/finschia-sdk/pull/901) Update release pipeline to match non-wasm env
* (ci) [\#983](https://github.com/Finschia/finschia-sdk/pull/983) update docker action to fit new repository

### Document Updates
* (x/foundation) [\#934](https://github.com/Finschia/finschia-sdk/pull/934) Update permlinks in x/foundation documents
* (x/collection,token) [\#944](https://github.com/Finschia/finschia-sdk/pull/944) Update comments in the x/token,collection events proto


