### PR TITLE
refactor: automate EventTypeMessage inclusion in every message execution (backport cosmos/cosmos-sdk#13532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 ### Improvements
+* (refactor) [\#1063](https://github.com/Finschia/finschia-sdk/pull/1063) Automate EventTypeMessage inclusion in every message execution (backport cosmos/cosmos-sdk#13532)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 ### Improvements
-* (refactor) [\#1063](https://github.com/Finschia/finschia-sdk/pull/1063) Automate EventTypeMessage inclusion in every message execution (backport cosmos/cosmos-sdk#13532)
 
 ### Bug Fixes
 
 ### Removed
 
 ### Breaking Changes
+* (refactor) [\#1063](https://github.com/Finschia/finschia-sdk/pull/1063) Automate EventTypeMessage inclusion in every message execution (backport cosmos/cosmos-sdk#13532)
 
 ### Build, CI
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -785,8 +785,8 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg) (*sdk.Result, error
 	// NOTE: GasWanted is determined by the AnteHandler and GasUsed by the GasMeter.
 	for i, msg := range msgs {
 		var (
-			msgResult    *sdk.Result
-			err          error
+			msgResult *sdk.Result
+			err       error
 		)
 
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {

--- a/baseapp/testutil/messages.go
+++ b/baseapp/testutil/messages.go
@@ -42,7 +42,7 @@ func (msg *MsgCounter2) ValidateBasic() error {
 var _ sdk.Msg = &MsgKeyValue{}
 
 func (msg *MsgKeyValue) GetSigners() []sdk.AccAddress {
-	if msg.Signer == "" {
+	if len(msg.Signer) == 0 {
 		return []sdk.AccAddress{}
 	}
 

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -146,12 +146,11 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPC() {
 				s.Require().NoError(err)
 				// Check the result and gas used are correct.
 				//
-				// The 12 events are:
-				// - Sending Fee to the pool: coin_spent, coin_received, transfer and message.sender=<val1>
-				// - tx.* events: tx.fee, tx.acc_seq, tx.signature
+				// NOTE(0Tech): This comment should be updated after applying #11985.
+				// Events from the antehandlers would not be included in the simulation. The 5 events are:
 				// - Sending Amount to recipient: coin_spent, coin_received, transfer and message.sender=<val1>
 				// - Msg events: message.module=bank, message.action=/cosmos.bank.v1beta1.MsgSend and message.sender=<val1> (in one message)
-				s.Require().Equal(12, len(res.GetResult().GetEvents()))
+				s.Require().Equal(5, len(res.GetResult().GetEvents()))
 				s.Require().True(res.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
 			}
 		})
@@ -192,7 +191,7 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPCGateway() {
 				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				// Check the result and gas used are correct.
-				s.Require().Equal(12, len(result.GetResult().GetEvents())) // See TestSimulateTx_GRPC for the 12 events.
+				s.Require().Equal(5, len(result.GetResult().GetEvents())) // See TestSimulateTx_GRPC for the 5 events.
 				s.Require().True(result.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
 			}
 		})

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -145,7 +145,13 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPC() {
 			} else {
 				s.Require().NoError(err)
 				// Check the result and gas used are correct.
-				s.Require().Equal(len(res.GetResult().GetEvents()), 6) // 1 coin recv 1 coin spent, 1 transfer, 3 messages.
+				//
+				// The 12 events are:
+				// - Sending Fee to the pool: coin_spent, coin_received, transfer and message.sender=<val1>
+				// - tx.* events: tx.fee, tx.acc_seq, tx.signature
+				// - Sending Amount to recipient: coin_spent, coin_received, transfer and message.sender=<val1>
+				// - Msg events: message.module=bank, message.action=/cosmos.bank.v1beta1.MsgSend and message.sender=<val1> (in one message)
+				s.Require().Equal(12, len(res.GetResult().GetEvents()))
 				s.Require().True(res.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
 			}
 		})
@@ -186,7 +192,7 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPCGateway() {
 				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				// Check the result and gas used are correct.
-				s.Require().Equal(len(result.GetResult().GetEvents()), 6) // 1 coin recv, 1 coin spent,1 transfer, 3 messages.
+				s.Require().Equal(12, len(result.GetResult().GetEvents())) // See TestSimulateTx_GRPC for the 12 events.
 				s.Require().True(result.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
 			}
 		})

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -151,7 +151,7 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPC() {
 				// - Sending Amount to recipient: coin_spent, coin_received, transfer and message.sender=<val1>
 				// - Msg events: message.module=bank, message.action=/cosmos.bank.v1beta1.MsgSend and message.sender=<val1> (in one message)
 				s.Require().Equal(5, len(res.GetResult().GetEvents()))
-				s.Require().True(res.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
+				s.Require().True(res.GetGasInfo().GetGasUsed() > 0) // Gas used sometimes change, just check it's not empty.
 			}
 		})
 	}

--- a/x/auth/vesting/msg_server.go
+++ b/x/auth/vesting/msg_server.go
@@ -89,12 +89,5 @@ func (s msgServer) CreateVestingAccount(goCtx context.Context, msg *types.MsgCre
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-		),
-	)
-
 	return &types.MsgCreateVestingAccountResponse{}, nil
 }

--- a/x/auth/vesting/types/constants.go
+++ b/x/auth/vesting/types/constants.go
@@ -4,9 +4,6 @@ const (
 	// ModuleName defines the module's name.
 	ModuleName = "vesting"
 
-	// AttributeValueCategory is an alias for the message event value.
-	AttributeValueCategory = ModuleName
-
 	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName
 )

--- a/x/bank/keeper/msg_server.go
+++ b/x/bank/keeper/msg_server.go
@@ -60,13 +60,6 @@ func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSe
 		}
 	}()
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-		),
-	)
-
 	return &types.MsgSendResponse{}, nil
 }
 
@@ -92,13 +85,6 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 	if err != nil {
 		return nil, err
 	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-		),
-	)
 
 	return &types.MsgMultiSendResponse{}, nil
 }

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -11,8 +11,6 @@ const (
 	AttributeKeyRecipient = "recipient"
 	AttributeKeySender    = "sender"
 
-	AttributeValueCategory = ModuleName
-
 	// supply and balance tracking events name and attributes
 	EventTypeCoinSpent    = "coin_spent"
 	EventTypeCoinReceived = "coin_received"

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -55,11 +55,6 @@ func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvar
 			types.EventTypeInvariant,
 			sdk.NewAttribute(types.AttributeKeyRoute, msg.InvariantRoute),
 		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCrisis),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
 	})
 
 	return &types.MsgVerifyInvariantResponse{}, nil

--- a/x/crisis/types/events.go
+++ b/x/crisis/types/events.go
@@ -4,6 +4,5 @@ package types
 const (
 	EventTypeInvariant = "invariant"
 
-	AttributeValueCrisis = ModuleName
-	AttributeKeyRoute    = "route"
+	AttributeKeyRoute = "route"
 )

--- a/x/distribution/keeper/msg_server.go
+++ b/x/distribution/keeper/msg_server.go
@@ -38,14 +38,6 @@ func (k msgServer) SetWithdrawAddress(goCtx context.Context, msg *types.MsgSetWi
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
-		),
-	)
-
 	return &types.MsgSetWithdrawAddressResponse{}, nil
 }
 
@@ -77,13 +69,6 @@ func (k msgServer) WithdrawDelegatorReward(goCtx context.Context, msg *types.Msg
 		}
 	}()
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
-		),
-	)
 	return &types.MsgWithdrawDelegatorRewardResponse{}, nil
 }
 
@@ -111,14 +96,6 @@ func (k msgServer) WithdrawValidatorCommission(goCtx context.Context, msg *types
 		}
 	}()
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.ValidatorAddress),
-		),
-	)
-
 	return &types.MsgWithdrawValidatorCommissionResponse{}, nil
 }
 
@@ -132,14 +109,6 @@ func (k msgServer) FundCommunityPool(goCtx context.Context, msg *types.MsgFundCo
 	if err := k.Keeper.FundCommunityPool(ctx, msg.Amount, depositer); err != nil {
 		return nil, err
 	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Depositor),
-		),
-	)
 
 	return &types.MsgFundCommunityPoolResponse{}, nil
 }

--- a/x/distribution/types/events.go
+++ b/x/distribution/types/events.go
@@ -11,6 +11,4 @@ const (
 
 	AttributeKeyWithdrawAddress = "withdraw_address"
 	AttributeKeyValidator       = "validator"
-
-	AttributeValueCategory = ModuleName
 )

--- a/x/evidence/keeper/msg_server.go
+++ b/x/evidence/keeper/msg_server.go
@@ -28,14 +28,6 @@ func (ms msgServer) SubmitEvidence(goCtx context.Context, msg *types.MsgSubmitEv
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.GetSubmitter().String()),
-		),
-	)
-
 	return &types.MsgSubmitEvidenceResponse{
 		Hash: evidence.Hash(),
 	}, nil

--- a/x/evidence/types/events.go
+++ b/x/evidence/types/events.go
@@ -4,6 +4,5 @@ package types
 const (
 	EventTypeSubmitEvidence = "submit_evidence"
 
-	AttributeValueCategory   = "evidence"
 	AttributeKeyEvidenceHash = "evidence_hash"
 )

--- a/x/feegrant/events.go
+++ b/x/feegrant/events.go
@@ -8,6 +8,4 @@ const (
 
 	AttributeKeyGranter = "granter"
 	AttributeKeyGrantee = "grantee"
-
-	AttributeValueCategory = ModuleName
 )

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -38,22 +38,14 @@ func (k msgServer) SubmitProposal(goCtx context.Context, msg *types.MsgSubmitPro
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.GetProposer().String()),
-		),
-	)
-
-	submitEvent := sdk.NewEvent(types.EventTypeSubmitProposal, sdk.NewAttribute(types.AttributeKeyProposalType, msg.GetContent().ProposalType()))
 	if votingStarted {
-		submitEvent = submitEvent.AppendAttributes(
-			sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, fmt.Sprintf("%d", proposal.ProposalId)),
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(types.EventTypeSubmitProposal,
+				sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, fmt.Sprintf("%d", proposal.ProposalId)),
+			),
 		)
 	}
 
-	ctx.EventManager().EmitEvent(submitEvent)
 	return &types.MsgSubmitProposalResponse{
 		ProposalId: proposal.ProposalId,
 	}, nil
@@ -79,14 +71,6 @@ func (k msgServer) Vote(goCtx context.Context, msg *types.MsgVote) (*types.MsgVo
 		},
 	)
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Voter),
-		),
-	)
-
 	return &types.MsgVoteResponse{}, nil
 }
 
@@ -109,14 +93,6 @@ func (k msgServer) VoteWeighted(goCtx context.Context, msg *types.MsgVoteWeighte
 		},
 	)
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Voter),
-		),
-	)
-
 	return &types.MsgVoteWeightedResponse{}, nil
 }
 
@@ -137,14 +113,6 @@ func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types
 		[]metrics.Label{
 			telemetry.NewLabel("proposal_id", strconv.Itoa(int(msg.ProposalId))),
 		},
-	)
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Depositor),
-		),
 	)
 
 	if votingStarted {

--- a/x/gov/types/events.go
+++ b/x/gov/types/events.go
@@ -12,7 +12,6 @@ const (
 	AttributeKeyOption             = "option"
 	AttributeKeyProposalID         = "proposal_id"
 	AttributeKeyVotingPeriodStart  = "voting_period_start"
-	AttributeValueCategory         = "governance"
 	AttributeValueProposalDropped  = "proposal_dropped"  // didn't meet min deposit
 	AttributeValueProposalPassed   = "proposal_passed"   // met vote quorum
 	AttributeValueProposalRejected = "proposal_rejected" // didn't meet vote quorum

--- a/x/slashing/keeper/msg_server.go
+++ b/x/slashing/keeper/msg_server.go
@@ -34,13 +34,5 @@ func (k msgServer) Unjail(goCtx context.Context, msg *types.MsgUnjail) (*types.M
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.ValidatorAddr),
-		),
-	)
-
 	return &types.MsgUnjailResponse{}, nil
 }

--- a/x/slashing/types/events.go
+++ b/x/slashing/types/events.go
@@ -14,5 +14,4 @@ const (
 
 	AttributeValueDoubleSign       = "double_sign"
 	AttributeValueMissingSignature = "missing_signature"
-	AttributeValueCategory         = ModuleName
 )

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -114,11 +114,6 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Value.String()),
 		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
-		),
 	})
 
 	return &types.MsgCreateValidatorResponse{}, nil
@@ -177,11 +172,6 @@ func (k msgServer) EditValidator(goCtx context.Context, msg *types.MsgEditValida
 			sdk.NewAttribute(types.AttributeKeyCommissionRate, validator.Commission.String()),
 			sdk.NewAttribute(types.AttributeKeyMinSelfDelegation, validator.MinSelfDelegation.String()),
 		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.ValidatorAddress),
-		),
 	})
 
 	return &types.MsgEditValidatorResponse{}, nil
@@ -235,11 +225,6 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
 			sdk.NewAttribute(types.AttributeKeyNewShares, newShares.String()),
-		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
 		),
 	})
 
@@ -302,11 +287,6 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
 			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
 		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
-		),
 	})
 
 	return &types.MsgBeginRedelegateResponse{
@@ -362,11 +342,6 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
 			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
-		),
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress),
 		),
 	})
 

--- a/x/staking/types/events.go
+++ b/x/staking/types/events.go
@@ -18,5 +18,4 @@ const (
 	AttributeKeyDelegator         = "delegator"
 	AttributeKeyCompletionTime    = "completion_time"
 	AttributeKeyNewShares         = "new_shares"
-	AttributeValueCategory        = ModuleName
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would add message event to every msgs in a tx. The event contains following attributes:
- sender
- action
- module

You may refer to the corresponding PR of the upstream.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
