### PR TITLE
docs: add detailed explanation about default events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Build, CI
 
 ### Document Updates
+* (docs) [\#1083](https://github.com/Finschia/finschia-sdk/pull/1083) Add detailed explanation about default events

--- a/docs/docs/core/08-events.md
+++ b/docs/docs/core/08-events.md
@@ -11,9 +11,15 @@ sidebar_position: 1
 
 There are a few events that are automatically emitted for all messages, directly from `baseapp`.
 
-* `message.action`: The name of the message type. Exactly one exists for each transaction message, in the first ABCI `Event` of each transaction message.
-* `message.sender`: The address of the message signer. Exactly one exists for each transaction message, in the first ABCI `Event` of each transaction message.
+* `message.action`: The name of the message type.
+* `message.sender`: The address of the message signer.
 * `message.module`: The name of the module that emitted the message.
+
+:::tip
+`baseapp` emits exactly one `message` event for each message before any other events emitted by the message.
+The `message` event contains at least 2 attributes, exactly one `action` and exactly one `sender`.
+The position of the event may change in the next major version.
+:::
 
 :::tip
 The module name is assumed by `baseapp` to be the second element of the message route: `"cosmos.bank.v1beta1.MsgSend" -> "bank"`.

--- a/docs/docs/core/08-events.md
+++ b/docs/docs/core/08-events.md
@@ -11,8 +11,8 @@ sidebar_position: 1
 
 There are a few events that are automatically emitted for all messages, directly from `baseapp`.
 
-* `message.action`: The name of the message type.
-* `message.sender`: The address of the message signer.
+* `message.action`: The name of the message type. Exactly one exists for each transaction message, in the first ABCI `Event` of each transaction message.
+* `message.sender`: The address of the message signer. Exactly one exists for each transaction message, in the first ABCI `Event` of each transaction message.
 * `message.module`: The name of the module that emitted the message.
 
 :::tip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It seems better to add more detailed information about default events emitted by baseapp. (Especially information about the event structure.)

This PR is trying to add such information to the document created by #1081.

## Checklist:
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
