### PR TITLE
fix: fix redundant priv-validator-key generation when running with kms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (third_party/proto) [\#1037](https://github.com/Finschia/finschia-sdk/pull/1037) change the proof.proto path to third_party/proto/confio
 * (ostracon) [\#1057](https://github.com/Finschia/finschia-sdk/pull/1057) Bump up Ostracon from to v1.1.1
 * (x/foundation) [\#1072](https://github.com/Finschia/finschia-sdk/pull/1072) Address generation of the empty coins in x/foundation (backport #952)
+* (cli) [\#1086](https://github.com/Finschia/finschia-sdk/pull/1086) Fix for redundant key generation. With running kms, generating priv-key is unnecessary.
 * (ostracon) [\#1089](https://github.com/Finschia/finschia-sdk/pull/1089) Bump up ostracon from v1.1.1 to v1.1.1-449aa3148b12
 
 ### Bug Fixes
-* (ledger) [\#1040](https://github.com/Finschia/finschia-sdk/pull/1040) fix a bug(unable to connect nano S plus ledger on ubuntu)
+* (ledger) [\#1040](https://github.com/Finschia/finschia-sdk/pull/1040) Fix a bug(unable to connect nano S plus ledger on ubuntu)
 * (x/foundation) [\#1053](https://github.com/Finschia/finschia-sdk/pull/1053) Make x/foundation MsgExec propagate events
 * (baseapp) [\#1091](https://github.com/cosmos/cosmos-sdk/pull/1091) Add `events.GetAttributes` and `event.GetAttribute` methods to simplify the retrieval of an attribute from event(s) (backport #1075)
 

--- a/server/start.go
+++ b/server/start.go
@@ -4,8 +4,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/Finschia/ostracon/config"
-	pvm "github.com/Finschia/ostracon/privval"
 	"net/http"
 	"os"
 	"runtime/pprof"
@@ -17,9 +15,11 @@ import (
 
 	"github.com/Finschia/ostracon/abci/server"
 	ostcmd "github.com/Finschia/ostracon/cmd/ostracon/commands"
+	"github.com/Finschia/ostracon/config"
 	ostos "github.com/Finschia/ostracon/libs/os"
 	"github.com/Finschia/ostracon/node"
 	"github.com/Finschia/ostracon/p2p"
+	pvm "github.com/Finschia/ostracon/privval"
 	"github.com/Finschia/ostracon/proxy"
 	"github.com/Finschia/ostracon/rpc/client/local"
 

--- a/server/start_test.go
+++ b/server/start_test.go
@@ -9,10 +9,13 @@ import (
 
 func TestGenPvFileOnlyWhenKmsAddressEmptyGenerateFiles(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.PrivValidatorKey = "./key.json"
-	cfg.PrivValidatorState = "./state.json"
-	defer os.Remove(cfg.PrivValidatorKey)
-	defer os.Remove(cfg.PrivValidatorState)
+	dir, err := os.MkdirTemp("", "start_test")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.RemoveAll(dir)
+	cfg.PrivValidatorKey = dir + "/key.json"
+	cfg.PrivValidatorState = dir + "/state.json"
 
 	pv := genPvFileOnlyWhenKmsAddressEmpty(cfg)
 

--- a/server/start_test.go
+++ b/server/start_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/Finschia/ostracon/config"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestGenPvFileOnlyWhenKmsAddressEmptyGenerateFiles(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.PrivValidatorKey = "./key.json"
+	cfg.PrivValidatorState = "./state.json"
+	defer os.Remove(cfg.PrivValidatorKey)
+	defer os.Remove(cfg.PrivValidatorState)
+
+	pv := genPvFileOnlyWhenKmsAddressEmpty(cfg)
+
+	assert.NotNil(t, pv)
+}
+
+func TestGenPvFileOnlyWhenKmsAddressEmptyShouldNotGenerateFiles(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.PrivValidatorListenAddr = "tcp://0.0.0.0:26659"
+
+	pv := genPvFileOnlyWhenKmsAddressEmpty(cfg)
+
+	assert.Nil(t, pv)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix for redundant key generation. With running kms, generating priv-key is unnecessary.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
