### PR TITLE
fix: support x/collection migration on old chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (ostracon) [\#1099](https://github.com/Finschia/finschia-sdk/pull/1099) feat!: remove libsodium vrf library.
 * (x/collection) [\#1102](https://github.com/finschia/finschia-sdk/pull/1102) Reject modifying NFT class with token index filled in MsgModify
 * (x/collection) [\#1105](https://github.com/Finschia/finschia-sdk/pull/1105) Add minted coins to balance in x/collection MsgMintFT
+* (x/collection) [\#1106](https://github.com/Finschia/finschia-sdk/pull/1106) Support x/collection migration on old chains
 
 ### Build, CI
 * (build,ci) [\#1043](https://github.com/Finschia/finschia-sdk/pull/1043) Update golang version to 1.20

--- a/x/collection/keeper/migrations/v2/store.go
+++ b/x/collection/keeper/migrations/v2/store.go
@@ -91,6 +91,8 @@ func updateContractFTStatistics(store storetypes.KVStore, contractID string, sup
 		return err
 	}
 
+	// In the old chains, classID of fungible tokens starts from zero
+	// In the new chains, it starts from one, but it does not hurts because amount of zero is not set to the store.
 	for intClassID := uint64(0); intClassID < nextClassIDs.Fungible.Uint64(); intClassID++ {
 		classID := fmt.Sprintf("%08x", intClassID)
 

--- a/x/collection/keeper/migrations/v2/store.go
+++ b/x/collection/keeper/migrations/v2/store.go
@@ -91,7 +91,7 @@ func updateContractFTStatistics(store storetypes.KVStore, contractID string, sup
 		return err
 	}
 
-	for intClassID := uint64(1); intClassID < nextClassIDs.Fungible.Uint64(); intClassID++ {
+	for intClassID := uint64(0); intClassID < nextClassIDs.Fungible.Uint64(); intClassID++ {
 		classID := fmt.Sprintf("%08x", intClassID)
 
 		// update supply
@@ -104,6 +104,7 @@ func updateContractFTStatistics(store storetypes.KVStore, contractID string, sup
 			}
 			store.Set(supplyKey, bz)
 		} else {
+			supply = sdk.ZeroInt()
 			store.Delete(supplyKey)
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would support old chains in which the default class ids start from 0.

related: #1105

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
