### PR TITLE
refactor: check statistics and balance on x/collection mint and burn operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#1072](https://github.com/Finschia/finschia-sdk/pull/1072) Address generation of the empty coins in x/foundation (backport #952)
 * (cli) [\#1086](https://github.com/Finschia/finschia-sdk/pull/1086) Fix for redundant key generation. With running kms, generating priv-key is unnecessary.
 * (ostracon) [\#1089](https://github.com/Finschia/finschia-sdk/pull/1089) Bump up ostracon from v1.1.1 to v1.1.1-449aa3148b12
+* (refactor) [\#1114](https://github.com/Finschia/finschia-sdk/pull/1114) Check statistics and balance on x/collection mint and burn operations
 
 ### Bug Fixes
 * (ledger) [\#1040](https://github.com/Finschia/finschia-sdk/pull/1040) Fix a bug(unable to connect nano S plus ledger on ubuntu)

--- a/x/collection/keeper/supply_test.go
+++ b/x/collection/keeper/supply_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	"math/rand"
 
 	sdk "github.com/Finschia/finschia-sdk/types"
 	"github.com/Finschia/finschia-sdk/x/collection"
@@ -94,21 +95,56 @@ func (s *KeeperTestSuite) TestMintFT() {
 		s.Run(name, func() {
 			ctx, _ := s.ctx.CacheContext()
 
+			// gather state
+			classID := collection.SplitTokenID(tc.amount.TokenId)
+			balanceBefore := s.keeper.GetBalance(ctx, tc.contractID, s.stranger, collection.NewFTID(classID))
+			supplyBefore := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			mintedBefore := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			burntBefore := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+
 			err := s.keeper.MintFT(ctx, tc.contractID, s.stranger, collection.NewCoins(tc.amount))
 			s.Require().ErrorIs(err, tc.err)
 			if tc.err != nil {
 				return
 			}
+
+			amount := tc.amount.Amount
+			balanceAfter := s.keeper.GetBalance(ctx, tc.contractID, s.stranger, collection.NewFTID(classID))
+			s.Require().Equal(balanceBefore.Add(amount), balanceAfter)
+			supplyAfter := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			s.Require().Equal(supplyBefore.Add(amount), supplyAfter)
+			mintedAfter := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			s.Require().Equal(mintedBefore.Add(amount), mintedAfter)
+			burntAfter := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+			s.Require().Equal(burntBefore, burntAfter)
 		})
 	}
 
 	// accumulation test
 	s.Run("accumulation test", func() {
 		ctx, _ := s.ctx.CacheContext()
-		numMints := int64(10)
+		numMints := int64(100)
+		contractID := s.contractID
+		classID := s.ftClassID
 		for i := int64(1); i <= numMints; i++ {
-			s.keeper.MintFT(ctx, s.contractID, s.stranger, collection.NewCoins(collection.NewFTCoin(s.ftClassID, sdk.OneInt())))
-			s.Require().Equal(sdk.NewInt(i), s.keeper.GetBalance(ctx, s.contractID, s.stranger, collection.NewFTID(s.ftClassID)))
+			amount := sdk.NewInt(rand.Int63())
+
+			// gather state
+			balanceBefore := s.keeper.GetBalance(ctx, s.contractID, s.stranger, collection.NewFTID(s.ftClassID))
+			supplyBefore := s.keeper.GetSupply(ctx, contractID, classID)
+			mintedBefore := s.keeper.GetMinted(ctx, contractID, classID)
+			burntBefore := s.keeper.GetBurnt(ctx, contractID, classID)
+
+			s.keeper.MintFT(ctx, s.contractID, s.stranger, collection.NewCoins(collection.NewFTCoin(s.ftClassID, amount)))
+
+			balanceAfter := s.keeper.GetBalance(ctx, s.contractID, s.stranger, collection.NewFTID(s.ftClassID))
+			s.Require().Equal(balanceBefore.Add(amount), balanceAfter)
+			supplyAfter := s.keeper.GetSupply(ctx, contractID, classID)
+			s.Require().Equal(supplyBefore.Add(amount), supplyAfter)
+			mintedAfter := s.keeper.GetMinted(ctx, contractID, classID)
+			s.Require().Equal(mintedBefore.Add(amount), mintedAfter)
+			burntAfter := s.keeper.GetBurnt(ctx, contractID, classID)
+			s.Require().Equal(burntBefore, burntAfter)
 		}
 	})
 }
@@ -116,21 +152,21 @@ func (s *KeeperTestSuite) TestMintFT() {
 func (s *KeeperTestSuite) TestMintNFT() {
 	testCases := map[string]struct {
 		contractID string
-		params     []collection.MintNFTParam
+		param      collection.MintNFTParam
 		err        error
 	}{
 		"valid request": {
 			contractID: s.contractID,
-			params:     []collection.MintNFTParam{{TokenType: s.nftClassID}},
+			param:      collection.MintNFTParam{TokenType: s.nftClassID},
 		},
 		"class not found": {
 			contractID: s.contractID,
-			params:     []collection.MintNFTParam{{TokenType: "deadbeef"}},
+			param:      collection.MintNFTParam{TokenType: "deadbeef"},
 			err:        collection.ErrTokenTypeNotExist,
 		},
 		"not a class id of nft": {
 			contractID: s.contractID,
-			params:     []collection.MintNFTParam{{TokenType: s.ftClassID}},
+			param:      collection.MintNFTParam{TokenType: s.ftClassID},
 			err:        collection.ErrTokenTypeNotExist,
 		},
 	}
@@ -139,11 +175,29 @@ func (s *KeeperTestSuite) TestMintNFT() {
 		s.Run(name, func() {
 			ctx, _ := s.ctx.CacheContext()
 
-			_, err := s.keeper.MintNFT(ctx, tc.contractID, s.stranger, tc.params)
+			// gather state
+			classID := tc.param.TokenType
+			supplyBefore := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			mintedBefore := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			burntBefore := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+
+			tokens, err := s.keeper.MintNFT(ctx, tc.contractID, s.stranger, []collection.MintNFTParam{tc.param})
 			s.Require().ErrorIs(err, tc.err)
 			if tc.err != nil {
 				return
 			}
+
+			amount := sdk.OneInt()
+			s.Require().Len(tokens, 1)
+			tokenID := tokens[0].TokenId
+			balanceAfter := s.keeper.GetBalance(ctx, tc.contractID, s.stranger, tokenID)
+			s.Require().Equal(amount, balanceAfter)
+			supplyAfter := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			s.Require().Equal(supplyBefore.Add(amount), supplyAfter)
+			mintedAfter := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			s.Require().Equal(mintedBefore.Add(amount), mintedAfter)
+			burntAfter := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+			s.Require().Equal(burntBefore, burntAfter)
 		})
 	}
 }
@@ -169,11 +223,28 @@ func (s *KeeperTestSuite) TestBurnCoins() {
 		s.Run(name, func() {
 			ctx, _ := s.ctx.CacheContext()
 
+			// gather state
+			classID := collection.SplitTokenID(tc.amount.TokenId)
+			balanceBefore := s.keeper.GetBalance(ctx, tc.contractID, s.vendor, collection.NewFTID(classID))
+			supplyBefore := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			mintedBefore := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			burntBefore := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+
 			_, err := s.keeper.BurnCoins(ctx, tc.contractID, s.vendor, collection.NewCoins(tc.amount))
 			s.Require().ErrorIs(err, tc.err)
 			if tc.err != nil {
 				return
 			}
+
+			amount := tc.amount.Amount
+			balanceAfter := s.keeper.GetBalance(ctx, tc.contractID, s.vendor, collection.NewFTID(classID))
+			s.Require().Equal(balanceBefore.Sub(amount), balanceAfter)
+			supplyAfter := s.keeper.GetSupply(ctx, tc.contractID, classID)
+			s.Require().Equal(supplyBefore.Sub(amount), supplyAfter)
+			mintedAfter := s.keeper.GetMinted(ctx, tc.contractID, classID)
+			s.Require().Equal(mintedBefore, mintedAfter)
+			burntAfter := s.keeper.GetBurnt(ctx, tc.contractID, classID)
+			s.Require().Equal(burntBefore.Add(amount), burntAfter)
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would compare the statistics before and after the supply operations.

related: #1105

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
