### PR TITLE
feat: add update-censorship cmd to x/foundation cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 * (third_party/proto) [\#1037](https://github.com/Finschia/finschia-sdk/pull/1037) change the proof.proto path to third_party/proto/confio
 * (ostracon) [\#1057](https://github.com/Finschia/finschia-sdk/pull/1057) Bump up Ostracon from to v1.1.1
+* (feat) [\#1121](https://github.com/Finschia/finschia-sdk/pull/1121) Add update-censorship cmd to x/foundation cli
 
 ### Bug Fixes
 * (ledger) [\#1040](https://github.com/Finschia/finschia-sdk/pull/1040) fix a bug(unable to connect nano S plus ledger on ubuntu)

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -89,6 +90,22 @@ func execFromString(execStr string) foundation.Exec {
 		exec = foundation.Exec_EXEC_TRY
 	}
 	return exec
+}
+
+func normalizeCensorshipAuthority(option string) string {
+	prefix := getEnumPrefix(foundation.CensorshipAuthority_name[0])
+	candidate := strings.ToUpper(prefix + option)
+	if _, ok := foundation.CensorshipAuthority_value[candidate]; ok {
+		return candidate
+	}
+
+	return option
+}
+
+func getEnumPrefix(str string) string {
+	delimiter := "_"
+	splitted := strings.Split(str, delimiter)
+	return strings.Join(splitted[:len(splitted) - 1], delimiter) + delimiter
 }
 
 // VoteOptionFromString returns a VoteOption from a string. It returns an error
@@ -569,9 +586,9 @@ Parameters:
     authority: the current authority of the censorship
     msg-type-url: the message type url of the censorship
     new-authority: a new authority of the censorship
-        CENSORSHIP_AUTHORITY_UNSPECIFIED: no authority, which means removing the censorship
-        CENSORSHIP_AUTHORITY_GOVERNANCE: x/gov
-        CENSORSHIP_AUTHORITY_FOUNDATION: x/foundation
+        unspecified: no authority, which means removing the censorship
+        governance: x/gov
+        foundation: x/foundation
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateGenerateOnly(cmd); err != nil {
@@ -583,7 +600,7 @@ Parameters:
 				return err
 			}
 
-			newAuthority, err := censorshipAuthorityFromString(args[2])
+			newAuthority, err := censorshipAuthorityFromString(normalizeCensorshipAuthority(args[2]))
 			if err != nil {
 				return err
 			}

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -589,7 +589,7 @@ Parameters:
 			}
 
 			msg := foundation.MsgUpdateCensorship{
-				Authority:  args[0],
+				Authority: args[0],
 				Censorship: foundation.Censorship{
 					MsgTypeUrl: args[1],
 					Authority:  newAuthority,

--- a/x/foundation/client/cli/tx.go
+++ b/x/foundation/client/cli/tx.go
@@ -105,7 +105,7 @@ func normalizeCensorshipAuthority(option string) string {
 func getEnumPrefix(str string) string {
 	delimiter := "_"
 	splitted := strings.Split(str, delimiter)
-	return strings.Join(splitted[:len(splitted) - 1], delimiter) + delimiter
+	return strings.Join(splitted[:len(splitted)-1], delimiter) + delimiter
 }
 
 // VoteOptionFromString returns a VoteOption from a string. It returns an error

--- a/x/foundation/client/testutil/tx.go
+++ b/x/foundation/client/testutil/tx.go
@@ -438,6 +438,14 @@ func (s *IntegrationTestSuite) TestNewTxCmdUpdateCensorship() {
 			},
 			true,
 		},
+		"valid abbreviation": {
+			[]string{
+				s.authority.String(),
+				foundation.ReceiveFromTreasuryAuthorization{}.MsgTypeURL(),
+				"governance",
+			},
+			true,
+		},
 		"wrong number of args": {
 			[]string{
 				s.authority.String(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would add update-censorship command, which helps generating Msg/UpdateCensorship.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
