### PR TITLE
fix: github release ci error

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,6 @@ jobs:
           make release
         env:
           GORELEASER_MOUNT_CONFIG: true
-          GORELEASER_IMAGE: line/goreleaserx:1.13.1-1.19.3
+          GORELEASER_IMAGE: goreleaser/goreleaser-cross:v1.21-v1.20.0
           GORELEASER_RELEASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,5 +53,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Event Breaking Changes
 
 ### Build, CI
+* (ci) [\#1149](https://github.com/Finschia/finschia-sdk/pull/1149) fix github release ci error
 
 ### Document Updates

--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ GORELEASER_BUILD_LDF := $(strip $(GORELEASER_BUILD_LDF))
 
 GORELEASER_SKIP_VALIDATE ?= false
 GORELEASER_DEBUG         ?= false
-GORELEASER_IMAGE         ?= line/goreleaserx:1.13.1-1.19.3
+GORELEASER_IMAGE         ?= goreleaser/goreleaser-cross:v1.21-v1.20.0
 GORELEASER_RELEASE       ?= false
 GO_MOD_NAME              := github.com/Finschia/finschia-sdk
 
@@ -578,7 +578,7 @@ release-snapshot:
 		-f "$(GORELEASER_CONFIG)" \
 		--skip-validate=$(GORELEASER_SKIP_VALIDATE) \
 		--debug=$(GORELEASER_DEBUG) \
-		--rm-dist
+		--clean
 
 release:
 	docker run --rm \
@@ -594,6 +594,6 @@ release:
 		--skip-validate=$(GORELEASER_SKIP_VALIDATE) \
 		--skip-announce=true \
 		--debug=$(GORELEASER_DEBUG) \
-		--rm-dist
+		--clean
 
 .PHONY: release-snapshot release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #1146 

Replace gorelease image to official image. And also change base golang version to v1.20.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
