### PR TITLE
test: check tx result on x/foundation e2e test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,7 @@ jobs:
           name: "${{ github.sha }}-e2e-coverage"
         continue-on-error: true
       - name: sonarcloud
-        if: ${{ env.GIT_DIFF && !github.event.pull_request.draft }}
+        if: ${{ env.GIT_DIFF && !github.event.pull_request.draft && env.SONAR_TOKEN != null}}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,8 +52,7 @@ issues:
     - text: "SA1019: codec.NewAminoCodec is deprecated" # TODO remove once migration path is set out
       linters:
         - staticcheck
-    - path: "client/cli"  # TODO(@0Tech): remove after foundation exec proposal removed
-      text: "SA1019: govcli.FlagDescription is deprecated"
+    - text: "SA1019: govcli.FlagDescription is deprecated" # TODO(@0Tech): remove after foundation exec proposal removed
       linters:
         - staticcheck
     - text: "leading space"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/crisis) [#1167](https://github.com/Finschia/finschia-sdk/pull/1167) Use `CacheContext()` in `AssertInvariants()`
 * (chore) [\#1168](https://github.com/Finschia/finschia-sdk/pull/1168) Replace `ExactArgs(0)` with `NoArgs()` in `x/upgrade` module
 * (server) [\#1175](https://github.com/Finschia/finschia-sdk/pull/1175) Use go embed for swagger
+* (x/foundation) [\#1237](https://github.com/Finschia/finschia-sdk/pull/1237) Check tx result on x/foundation e2e test
 
 ### Bug Fixes
 * chore(deps) [\#1141](https://github.com/Finschia/finschia-sdk/pull/1141) Bump github.com/cosmos/ledger-cosmos-go from 0.12.2 to 0.13.2 to fix ledger signing issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/crisis) [#1167](https://github.com/Finschia/finschia-sdk/pull/1167) Use `CacheContext()` in `AssertInvariants()`
 * (chore) [\#1168](https://github.com/Finschia/finschia-sdk/pull/1168) Replace `ExactArgs(0)` with `NoArgs()` in `x/upgrade` module
 * (server) [\#1175](https://github.com/Finschia/finschia-sdk/pull/1175) Use go embed for swagger
-* (x/foundation) [\#1237](https://github.com/Finschia/finschia-sdk/pull/1237) Check tx result on x/foundation e2e test
+* (e2e) [\#1237](https://github.com/Finschia/finschia-sdk/pull/1237) Check tx result on x/foundation e2e test
 
 ### Bug Fixes
 * chore(deps) [\#1141](https://github.com/Finschia/finschia-sdk/pull/1141) Bump github.com/cosmos/ledger-cosmos-go from 0.12.2 to 0.13.2 to fix ledger signing issue

--- a/scripts/go-lint-all.bash
+++ b/scripts/go-lint-all.bash
@@ -31,7 +31,7 @@ else
   for f in $(dirname $(echo "$GIT_DIFF" | tr -d "'") | uniq); do
     echo "linting $f [$(date -Iseconds -u)]" &&
     cd $f &&
-    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@" &&
+    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@"
     cd $REPO_ROOT
   done
 fi

--- a/tests/e2e/foundation/grpc.go
+++ b/tests/e2e/foundation/grpc.go
@@ -3,7 +3,7 @@ package foundation
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/math"
 

--- a/tests/e2e/foundation/query.go
+++ b/tests/e2e/foundation/query.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	cmtcli "github.com/cometbft/cometbft/libs/cli"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/math"
 

--- a/tests/e2e/foundation/suite.go
+++ b/tests/e2e/foundation/suite.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stretchr/testify/suite"
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/suite"
 
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/math"

--- a/tests/e2e/foundation/tx.go
+++ b/tests/e2e/foundation/tx.go
@@ -61,7 +61,9 @@ func (s *E2ETestSuite) TestNewTxCmdFundTreasury() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }
@@ -276,7 +278,9 @@ func (s *E2ETestSuite) TestNewTxCmdSubmitProposal() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }
@@ -290,7 +294,12 @@ func (s *E2ETestSuite) TestNewTxCmdWithdrawProposal() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, math.NewInt(10)))),
 	}
 
-	proposalID := 2
+	proposalID := s.submitProposal(&foundation.MsgWithdrawFromTreasury{
+		Authority: s.bytesToString(s.authority),
+		To:        s.bytesToString(s.stranger),
+		Amount:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(123))),
+	}, false)
+
 	testCases := map[string]struct {
 		args  []string
 		valid bool
@@ -328,7 +337,9 @@ func (s *E2ETestSuite) TestNewTxCmdWithdrawProposal() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }
@@ -342,7 +353,12 @@ func (s *E2ETestSuite) TestNewTxCmdVote() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, math.NewInt(10)))),
 	}
 
-	proposalID := 3
+	proposalID := s.submitProposal(&foundation.MsgWithdrawFromTreasury{
+		Authority: s.bytesToString(s.authority),
+		To:        s.bytesToString(s.stranger),
+		Amount:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(123))),
+	}, false)
+
 	testCases := map[string]struct {
 		args  []string
 		valid bool
@@ -384,7 +400,9 @@ func (s *E2ETestSuite) TestNewTxCmdVote() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }
@@ -435,7 +453,9 @@ func (s *E2ETestSuite) TestNewTxCmdExec() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }
@@ -547,7 +567,9 @@ func (s *E2ETestSuite) TestNewTxCmdLeaveFoundation() {
 			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res), out)
 			s.Require().Zero(res.Code, out)
 
-			s.Require().NoError(s.network.WaitForNextBlock())
+			res, err = clitestutil.GetTxResponse(s.network, val.ClientCtx, res.TxHash)
+			s.Require().NoError(err)
+			s.Require().Zero(res.Code, res.RawLog)
 		})
 	}
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
 	// this version is not used as it is always replaced by the latest Cosmos SDK version
 	github.com/cosmos/cosmos-sdk v0.51.0
-	github.com/cosmos/gogoproto v1.4.11 // indirect
+	github.com/cosmos/gogoproto v1.4.11
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/stretchr/testify v1.8.4
@@ -33,7 +33,6 @@ require (
 require (
 	github.com/Finschia/finschia-sdk/simapp v0.0.0-00010101000000-000000000000
 	github.com/Finschia/finschia-sdk/x/foundation v0.0.0-00010101000000-000000000000
-	github.com/gogo/protobuf v1.3.2
 )
 
 require (
@@ -42,7 +41,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.3 // indirect
 	cloud.google.com/go/storage v1.30.1 // indirect
-	cosmossdk.io/client/v2 v2.0.0-beta.1 // indirect
 	cosmossdk.io/collections v0.4.0 // indirect
 	cosmossdk.io/x/circuit v0.1.0 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
@@ -93,6 +91,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -189,8 +189,6 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
 cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
 cosmossdk.io/api v0.7.2 h1:BO3i5fvKMKvfaUiMkCznxViuBEfyWA/k6w2eAF6q1C4=
 cosmossdk.io/api v0.7.2/go.mod h1:IcxpYS5fMemZGqyYtErK7OqvdM0C8kdW3dq8Q/XIG38=
-cosmossdk.io/client/v2 v2.0.0-beta.1 h1:XkHh1lhrLYIT9zKl7cIOXUXg2hdhtjTPBUfqERNA1/Q=
-cosmossdk.io/client/v2 v2.0.0-beta.1/go.mod h1:JEUSu9moNZQ4kU3ir1DKD5eU4bllmAexrGWjmb9k8qU=
 cosmossdk.io/collections v0.4.0 h1:PFmwj2W8szgpD5nOd8GWH6AbYNi1f2J6akWXJ7P5t9s=
 cosmossdk.io/collections v0.4.0/go.mod h1:oa5lUING2dP+gdDquow+QjlF45eL1t4TJDypgGd+tv0=
 cosmossdk.io/core v0.11.0 h1:vtIafqUi+1ZNAE/oxLOQQ7Oek2n4S48SWLG8h/+wdbo=

--- a/x/foundation/authz.go
+++ b/x/foundation/authz.go
@@ -1,7 +1,7 @@
 package foundation
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/x/foundation/events.go
+++ b/x/foundation/events.go
@@ -1,7 +1,7 @@
 package foundation
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/x/foundation/foundation.go
+++ b/x/foundation/foundation.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
 	errorsmod "cosmossdk.io/errors"

--- a/x/foundation/genesis.go
+++ b/x/foundation/genesis.go
@@ -1,7 +1,7 @@
 package foundation
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/math"

--- a/x/foundation/go.mod
+++ b/x/foundation/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
 	github.com/cosmos/cosmos-sdk v0.50.2
 	github.com/cosmos/gogoproto v1.4.11
-	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
@@ -73,6 +72,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/x/foundation/keeper/internal/grpc_query.go
+++ b/x/foundation/keeper/internal/grpc_query.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"context"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/x/foundation/msgs.go
+++ b/x/foundation/msgs.go
@@ -1,7 +1,7 @@
 package foundation
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The e2e test for x/foundation did not check the error code of the txs result.
Applying this patch, the test would check the tx result included in the blocks.

minor: update gogoproto package

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
