### PR TITLE
fix: export x/collection params into genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 * chore(deps) [\#1141](https://github.com/Finschia/finschia-sdk/pull/1141) Bump github.com/cosmos/ledger-cosmos-go from 0.12.2 to 0.13.2 to fix ledger signing issue
 * (x/auth, x/slashing) [\#1179](https://github.com/Finschia/finschia-sdk/pull/1179) modify missing changes of converting to tendermint
+* (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
 
 ### Removed
 

--- a/x/collection/keeper/genesis.go
+++ b/x/collection/keeper/genesis.go
@@ -211,8 +211,8 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *collection.GenesisState {
 	contracts := k.getContracts(ctx)
 
 	return &collection.GenesisState{
-		Contracts:      contracts,
 		Params:         k.GetParams(ctx),
+		Contracts:      contracts,
 		NextClassIds:   k.getAllNextClassIDs(ctx),
 		Classes:        k.getClasses(ctx, contracts),
 		NextTokenIds:   k.getNextTokenIDs(ctx, contracts),

--- a/x/collection/keeper/genesis.go
+++ b/x/collection/keeper/genesis.go
@@ -212,6 +212,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *collection.GenesisState {
 
 	return &collection.GenesisState{
 		Contracts:      contracts,
+		Params:         k.GetParams(ctx),
 		NextClassIds:   k.getAllNextClassIDs(ctx),
 		Classes:        k.getClasses(ctx, contracts),
 		NextTokenIds:   k.getNextTokenIDs(ctx, contracts),

--- a/x/collection/keeper/genesis_test.go
+++ b/x/collection/keeper/genesis_test.go
@@ -28,3 +28,11 @@ func (s *KeeperTestSuite) TestImportExportGenesis() {
 	newGenesis := s.keeper.ExportGenesis(s.ctx)
 	s.Require().Equal(genesis, newGenesis)
 }
+
+func (s *KeeperTestSuite) TestExportGenesis() {
+	genesis := s.keeper.ExportGenesis(s.ctx)
+
+	params := genesis.Params
+	s.Require().NotZero(params.DepthLimit)
+	s.Require().NotZero(params.WidthLimit)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
x/collection does not export its params into genesis. This patch addresses the problem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
