### PR TITLE
Ignore gas when zkauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 * (x/zkauth) [\#1239](https://github.com/Finschia/finschia-sdk/pull/1239) add CalculateAllInputsHash in ZKAuthInputs
+* (x/zkauth) [\#1275](https://github.com/Finschia/finschia-sdk/pull/1275) Ignore gas when zkauth
 
 ### Bug Fixes
 

--- a/baseapp/block_gas_test.go
+++ b/baseapp/block_gas_test.go
@@ -125,7 +125,7 @@ func TestBaseApp_BlockGas(t *testing.T) {
 				require.Equal(t, []byte("ok"), okValue)
 			}
 			// check block gas is always consumed
-			baseGas := uint64(34824) // baseGas is the gas consumed before tx msg
+			baseGas := uint64(37352) // baseGas is the gas consumed before tx msg
 			expGasConsumed := addUint64Saturating(tc.gasToConsume, baseGas)
 			if expGasConsumed > txtypes.MaxGasWanted {
 				// capped by gasLimit

--- a/x/zkauth/ante/zkauth.go
+++ b/x/zkauth/ante/zkauth.go
@@ -161,6 +161,7 @@ func (zsg ZKAuthSigGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, s
 	}
 
 	// Case of zkauth msg, does nothing in this case
+	// TODO: We need an algorithm to deduct fees from zkauth addresses.
 	return next(ctx, tx, simulate)
 }
 

--- a/x/zkauth/testutil/keeper.go
+++ b/x/zkauth/testutil/keeper.go
@@ -20,6 +20,9 @@ import (
 	authkeeper "github.com/Finschia/finschia-sdk/x/auth/keeper"
 	xauthsigning "github.com/Finschia/finschia-sdk/x/auth/signing"
 	authtypes "github.com/Finschia/finschia-sdk/x/auth/types"
+	banktypes "github.com/Finschia/finschia-sdk/x/bank/types"
+	bankpluskeeper "github.com/Finschia/finschia-sdk/x/bankplus/keeper"
+	feegrantkeeper "github.com/Finschia/finschia-sdk/x/feegrant/keeper"
 	minttypes "github.com/Finschia/finschia-sdk/x/mint/types"
 	"github.com/Finschia/finschia-sdk/x/zkauth/keeper"
 	"github.com/Finschia/finschia-sdk/x/zkauth/types"
@@ -29,6 +32,8 @@ type TestApp struct {
 	Simapp          *simapp.SimApp
 	ZKAuthKeeper    *keeper.Keeper
 	AccountKeeper   authkeeper.AccountKeeper
+	BankKeeper      bankpluskeeper.Keeper
+	FeeGrantKeeper  feegrantkeeper.Keeper
 	SignModeHandler xauthsigning.SignModeHandler
 	Ctx             sdk.Context
 	ClientCtx       client.Context
@@ -90,11 +95,16 @@ func ZkAuthKeeper(t testing.TB) TestApp {
 		appCodec, app.GetKey(types.StoreKey), app.GetSubspace(authtypes.ModuleName),
 		authtypes.ProtoBaseAccount, maccPerms,
 	)
+	feeGrantKeeper := feegrantkeeper.NewKeeper(appCodec, app.GetKey(types.StoreKey), authKeeper)
+	bankKeeper := bankpluskeeper.NewBaseKeeper(
+		appCodec, app.GetKey(types.StoreKey), authKeeper, app.GetSubspace(banktypes.ModuleName), app.BlockedAddrs(), false)
 
 	testApp := TestApp{
 		Simapp:          app,
 		ZKAuthKeeper:    k,
 		AccountKeeper:   authKeeper,
+		BankKeeper:      bankKeeper,
+		FeeGrantKeeper:  feeGrantKeeper,
 		SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 		Ctx:             ctx,
 		ClientCtx:       clientCtx,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
zkauth uses a ephemeral key to perform tx signature and includes zkauth signature in msg.

- Ephemeral keys do not have the ability to pay fees, so ignore DeductFeeDecorator when zkauth is included.
- It is originally necessary to subtract the fee from the zkauth address, but I will leave this as a todo and temporarily decide that the fee will not occur.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
