### PR TITLE
fix: add init logic of module accounts just in case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 * chore(deps) [\#1141](https://github.com/Finschia/finschia-sdk/pull/1141) Bump github.com/cosmos/ledger-cosmos-go from 0.12.2 to 0.13.2 to fix ledger signing issue
 * (x/auth, x/slashing) [\#1179](https://github.com/Finschia/finschia-sdk/pull/1179) modify missing changes of converting to tendermint
+* (x/foundation) [\#1277](https://github.com/Finschia/finschia-sdk/pull/1277) add init logic of foundation module accounts to InitGenesis in order to eliminate potential panic
+
 
 ### Removed
 

--- a/baseapp/block_gas_test.go
+++ b/baseapp/block_gas_test.go
@@ -100,7 +100,7 @@ func TestBaseApp_BlockGas(t *testing.T) {
 			txBuilder.SetFeeAmount(feeAmount)
 			txBuilder.SetGasLimit(txtypes.MaxGasWanted) // tx validation checks that gasLimit can't be bigger than this
 
-			privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{6}, []uint64{0}
+			privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{8}, []uint64{0}
 			_, txBytes, err := createTestTx(encCfg.TxConfig, txBuilder, privs, accNums, accSeqs, ctx.ChainID())
 			require.NoError(t, err)
 

--- a/x/foundation/keeper/internal/genesis.go
+++ b/x/foundation/keeper/internal/genesis.go
@@ -48,6 +48,9 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *foundation.GenesisState) erro
 
 	k.SetPool(ctx, data.Pool)
 
+	// init module accounts just in case
+	_ = k.authKeeper.GetModuleAccount(ctx, foundation.ModuleName)
+	_ = k.authKeeper.GetModuleAccount(ctx, foundation.TreasuryName)
 	return nil
 }
 

--- a/x/foundation/keeper/internal/genesis.go
+++ b/x/foundation/keeper/internal/genesis.go
@@ -1,7 +1,10 @@
 package internal
 
 import (
+	"fmt"
+
 	sdk "github.com/Finschia/finschia-sdk/types"
+
 	"github.com/Finschia/finschia-sdk/x/foundation"
 )
 
@@ -49,8 +52,12 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *foundation.GenesisState) erro
 	k.SetPool(ctx, data.Pool)
 
 	// init module accounts just in case
-	_ = k.authKeeper.GetModuleAccount(ctx, foundation.ModuleName)
-	_ = k.authKeeper.GetModuleAccount(ctx, foundation.TreasuryName)
+	if acc := k.authKeeper.GetModuleAccount(ctx, foundation.ModuleName); acc == nil {
+		panic(fmt.Sprintf("failed to create module account=%s", foundation.ModuleName))
+	}
+	if acc := k.authKeeper.GetModuleAccount(ctx, foundation.TreasuryName); acc == nil {
+		panic(fmt.Sprintf("failed to create module account=%s", foundation.TreasuryName))
+	}
 	return nil
 }
 

--- a/x/foundation/keeper/internal/genesis.go
+++ b/x/foundation/keeper/internal/genesis.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/Finschia/finschia-sdk/types"
-
 	"github.com/Finschia/finschia-sdk/x/foundation"
 )
 

--- a/x/foundation/keeper/internal/genesis_test.go
+++ b/x/foundation/keeper/internal/genesis_test.go
@@ -303,11 +303,11 @@ func TestShouldPanicWhenFailToGenerateFoundationModuleAccountInInitGenesis(t *te
 	testCases := map[string]struct {
 		mockAccKeeper *stubAccKeeper
 	}{
-		"failed to generate foundation module account=" + foundation.ModuleName: {
-			mockAccKeeper: &stubAccKeeper{name: foundation.ModuleName},
+		"failed to generate module account=" + foundation.ModuleName: {
+			mockAccKeeper: &stubAccKeeper{nameToFail: foundation.ModuleName},
 		},
-		"failed to generate foundation module account=" + foundation.TreasuryName: {
-			mockAccKeeper: &stubAccKeeper{name: foundation.TreasuryName},
+		"failed to generate module account=" + foundation.TreasuryName: {
+			mockAccKeeper: &stubAccKeeper{nameToFail: foundation.TreasuryName},
 		},
 	}
 
@@ -334,12 +334,12 @@ func TestShouldPanicWhenFailToGenerateFoundationModuleAccountInInitGenesis(t *te
 }
 
 type stubAccKeeper struct {
-	name string
+	nameToFail string
 }
 
 func (s *stubAccKeeper) GetModuleAccount(_ sdk.Context, name string) authtypes.ModuleAccountI {
-	if s.name == name {
-		return authtypes.NewEmptyModuleAccount("dontcare")
+	if s.nameToFail == name {
+		return nil
 	}
-	return nil
+	return authtypes.NewEmptyModuleAccount("dontcare")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* (audit issue) add init logic of foundation module accounts to InitGenesis in order to eliminate potential panic
* ~NOTE: This is likely to change account number state in auth module.~ --> InitGenesis never runs more than once

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
