### PR TITLE
fix: add nft id validation to MsgSendNFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/crisis) [#1167](https://github.com/Finschia/finschia-sdk/pull/1167) Use `CacheContext()` in `AssertInvariants()`
 * (chore) [\#1168](https://github.com/Finschia/finschia-sdk/pull/1168) Replace `ExactArgs(0)` with `NoArgs()` in `x/upgrade` module
 * (server) [\#1175](https://github.com/Finschia/finschia-sdk/pull/1175) Use go embed for swagger
+* (x/collection) [\#1287](https://github.com/Finschia/finschia-sdk/pull/1287) add nft id validation to MsgSendNFT
 
 ### Bug Fixes
 * chore(deps) [\#1141](https://github.com/Finschia/finschia-sdk/pull/1141) Bump github.com/cosmos/ledger-cosmos-go from 0.12.2 to 0.13.2 to fix ledger signing issue

--- a/x/collection/msgs.go
+++ b/x/collection/msgs.go
@@ -340,7 +340,7 @@ func (m MsgSendNFT) ValidateBasic() error {
 		return ErrEmptyField.Wrap("token ids cannot be empty")
 	}
 	for _, id := range m.TokenIds {
-		if err := ValidateTokenID(id); err != nil {
+		if err := ValidateNFTID(id); err != nil {
 			return err
 		}
 	}

--- a/x/collection/msgs_test.go
+++ b/x/collection/msgs_test.go
@@ -259,6 +259,13 @@ func TestMsgSendNFT(t *testing.T) {
 			ids:        []string{""},
 			err:        collection.ErrInvalidTokenID,
 		},
+		"FT ids": {
+			contractID: "deadbeef",
+			from:       addrs[0],
+			to:         addrs[1],
+			ids:        []string{collection.NewFTID("deadbeef")},
+			err:        sdkerrors.ErrInvalidRequest.Wrapf("invalid id: %s", collection.NewFTID("deadbeef")),
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #XXXX

This PR adds nft id validation to MsgSendNFT.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The ValidateBasic() method of message MsgSendNFT is used to check the validity of the message during the stateless validation process. The current implementation of ValidateBasic() checks whether the provided IDs are valid TokenIDs with function ValidateTokenID():

It is insufficient as it allows Fungible tokens to pass through, potentially leading to unexpected errors since Fungible tokens are not intended to be processed by this function.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
