### PR TITLE
fix: use accAddress to compare in validatebasic function in collection & token modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth) [#1274](https://github.com/Finschia/finschia-sdk/pull/1274) `ModuleAccount.Validate` now reports a nil `.BaseAccount` instead of panicking.
 * (x/collection) [\#1276](https://github.com/Finschia/finschia-sdk/pull/1276) eliminates potential risk for Insufficient Sanity Check of tokenID in Genesis 
 * (x/foundation) [\#1277](https://github.com/Finschia/finschia-sdk/pull/1277) add init logic of foundation module accounts to InitGenesis in order to eliminate potential panic
+* (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 
 ### Removed
 

--- a/x/collection/msgs.go
+++ b/x/collection/msgs.go
@@ -474,14 +474,17 @@ func (m MsgRevokeOperator) ValidateBasic() error {
 		return err
 	}
 
-	if _, err := sdk.AccAddressFromBech32(m.Holder); err != nil {
+	holderAcc, err := sdk.AccAddressFromBech32(m.Holder)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid holder address: %s", m.Holder)
 	}
-	if _, err := sdk.AccAddressFromBech32(m.Operator); err != nil {
+
+	operatorAcc, err := sdk.AccAddressFromBech32(m.Operator)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid operator address: %s", m.Operator)
 	}
 
-	if m.Operator == m.Holder {
+	if holderAcc.Equals(operatorAcc) {
 		return ErrApproverProxySame
 	}
 

--- a/x/collection/msgs.go
+++ b/x/collection/msgs.go
@@ -428,14 +428,17 @@ func (m MsgAuthorizeOperator) ValidateBasic() error {
 		return err
 	}
 
-	if _, err := sdk.AccAddressFromBech32(m.Holder); err != nil {
+	holderAcc, err := sdk.AccAddressFromBech32(m.Holder)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid holder address: %s", m.Holder)
 	}
-	if _, err := sdk.AccAddressFromBech32(m.Operator); err != nil {
+
+	operatorAcc, err := sdk.AccAddressFromBech32(m.Operator)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid operator address: %s", m.Operator)
 	}
 
-	if m.Operator == m.Holder {
+	if holderAcc.Equals(operatorAcc) {
 		return ErrApproverProxySame
 	}
 

--- a/x/collection/msgs_test.go
+++ b/x/collection/msgs_test.go
@@ -440,15 +440,15 @@ func TestMsgAuthorizeOperator(t *testing.T) {
 }
 
 func TestMsgRevokeOperator(t *testing.T) {
-	addrs := make([]sdk.AccAddress, 2)
+	addrs := make([]string, 2)
 	for i := range addrs {
-		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	}
 
 	testCases := map[string]struct {
 		contractID string
-		holder     sdk.AccAddress
-		operator   sdk.AccAddress
+		holder     string
+		operator   string
 		err        error
 	}{
 		"valid msg": {
@@ -471,14 +471,26 @@ func TestMsgRevokeOperator(t *testing.T) {
 			holder:     addrs[0],
 			err:        sdkerrors.ErrInvalidAddress,
 		},
+		"proxy and approver should be different": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   addrs[0],
+			err:        collection.ErrApproverProxySame,
+		},
+		"proxy and approver should be different (uppercase)": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   strings.ToUpper(addrs[0]),
+			err:        collection.ErrApproverProxySame,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			msg := collection.MsgRevokeOperator{
 				ContractId: tc.contractID,
-				Holder:     tc.holder.String(),
-				Operator:   tc.operator.String(),
+				Holder:     tc.holder,
+				Operator:   tc.operator,
 			}
 
 			require.ErrorIs(t, msg.ValidateBasic(), tc.err)
@@ -486,7 +498,7 @@ func TestMsgRevokeOperator(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, []sdk.AccAddress{tc.holder}, msg.GetSigners())
+			require.Equal(t, []sdk.AccAddress{sdk.MustAccAddressFromBech32(tc.holder)}, msg.GetSigners())
 		})
 	}
 }

--- a/x/collection/msgs_test.go
+++ b/x/collection/msgs_test.go
@@ -376,15 +376,15 @@ func TestMsgOperatorSendNFT(t *testing.T) {
 }
 
 func TestMsgAuthorizeOperator(t *testing.T) {
-	addrs := make([]sdk.AccAddress, 2)
+	addrs := make([]string, 2)
 	for i := range addrs {
-		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	}
 
 	testCases := map[string]struct {
 		contractID string
-		holder     sdk.AccAddress
-		operator   sdk.AccAddress
+		holder     string
+		operator   string
 		err        error
 	}{
 		"valid msg": {
@@ -407,14 +407,26 @@ func TestMsgAuthorizeOperator(t *testing.T) {
 			holder:     addrs[0],
 			err:        sdkerrors.ErrInvalidAddress,
 		},
+		"proxy and approver should be different": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   addrs[0],
+			err:        collection.ErrApproverProxySame,
+		},
+		"proxy and approver should be different (uppercase)": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   strings.ToUpper(addrs[0]),
+			err:        collection.ErrApproverProxySame,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			msg := collection.MsgAuthorizeOperator{
 				ContractId: tc.contractID,
-				Holder:     tc.holder.String(),
-				Operator:   tc.operator.String(),
+				Holder:     tc.holder,
+				Operator:   tc.operator,
 			}
 
 			require.ErrorIs(t, msg.ValidateBasic(), tc.err)
@@ -422,7 +434,7 @@ func TestMsgAuthorizeOperator(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, []sdk.AccAddress{tc.holder}, msg.GetSigners())
+			require.Equal(t, []sdk.AccAddress{sdk.MustAccAddressFromBech32(tc.holder)}, msg.GetSigners())
 		})
 	}
 }

--- a/x/token/msgs.go
+++ b/x/token/msgs.go
@@ -103,14 +103,17 @@ func (m MsgRevokeOperator) ValidateBasic() error {
 		return err
 	}
 
-	if _, err := sdk.AccAddressFromBech32(m.Holder); err != nil {
+	holderAcc, err := sdk.AccAddressFromBech32(m.Holder)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid holder address: %s", m.Holder)
 	}
-	if _, err := sdk.AccAddressFromBech32(m.Operator); err != nil {
+
+	operatorAcc, err := sdk.AccAddressFromBech32(m.Operator)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid operator address: %s", m.Operator)
 	}
 
-	if m.Operator == m.Holder {
+	if holderAcc.Equals(operatorAcc) {
 		return ErrApproverProxySame
 	}
 

--- a/x/token/msgs.go
+++ b/x/token/msgs.go
@@ -146,14 +146,17 @@ func (m MsgAuthorizeOperator) ValidateBasic() error {
 		return err
 	}
 
-	if _, err := sdk.AccAddressFromBech32(m.Holder); err != nil {
+	holderAcc, err := sdk.AccAddressFromBech32(m.Holder)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid holder address: %s", m.Holder)
 	}
-	if _, err := sdk.AccAddressFromBech32(m.Operator); err != nil {
+
+	operatorAcc, err := sdk.AccAddressFromBech32(m.Operator)
+	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid operator address: %s", m.Operator)
 	}
 
-	if m.Operator == m.Holder {
+	if holderAcc.Equals(operatorAcc) {
 		return ErrApproverProxySame
 	}
 

--- a/x/token/msgs_test.go
+++ b/x/token/msgs_test.go
@@ -221,15 +221,15 @@ func TestMsgRevokeOperator(t *testing.T) {
 }
 
 func TestMsgAuthorizeOperator(t *testing.T) {
-	addrs := make([]sdk.AccAddress, 2)
+	addrs := make([]string, 2)
 	for i := range addrs {
-		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	}
 
 	testCases := map[string]struct {
 		contractID string
-		holder     sdk.AccAddress
-		operator   sdk.AccAddress
+		holder     string
+		operator   string
 		err        error
 	}{
 		"valid msg": {
@@ -258,14 +258,20 @@ func TestMsgAuthorizeOperator(t *testing.T) {
 			operator:   addrs[0],
 			err:        token.ErrApproverProxySame,
 		},
+		"proxy and approver should be different (uppercase)": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   strings.ToUpper(addrs[0]),
+			err:        token.ErrApproverProxySame,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			msg := token.MsgAuthorizeOperator{
 				ContractId: tc.contractID,
-				Holder:     tc.holder.String(),
-				Operator:   tc.operator.String(),
+				Holder:     tc.holder,
+				Operator:   tc.operator,
 			}
 
 			err := msg.ValidateBasic()
@@ -274,7 +280,7 @@ func TestMsgAuthorizeOperator(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, []sdk.AccAddress{tc.holder}, msg.GetSigners())
+			require.Equal(t, []sdk.AccAddress{sdk.MustAccAddressFromBech32(tc.holder)}, msg.GetSigners())
 		})
 	}
 }

--- a/x/token/msgs_test.go
+++ b/x/token/msgs_test.go
@@ -162,15 +162,15 @@ func TestMsgOperatorSend(t *testing.T) {
 }
 
 func TestMsgRevokeOperator(t *testing.T) {
-	addrs := make([]sdk.AccAddress, 2)
+	addrs := make([]string, 2)
 	for i := range addrs {
-		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+		addrs[i] = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
 	}
 
 	testCases := map[string]struct {
 		contractID string
-		holder     sdk.AccAddress
-		operator   sdk.AccAddress
+		holder     string
+		operator   string
 		err        error
 	}{
 		"valid msg": {
@@ -199,14 +199,20 @@ func TestMsgRevokeOperator(t *testing.T) {
 			operator:   addrs[0],
 			err:        token.ErrApproverProxySame,
 		},
+		"operator and holder should be different (uppercase)": {
+			contractID: "deadbeef",
+			holder:     addrs[0],
+			operator:   strings.ToUpper(addrs[0]),
+			err:        token.ErrApproverProxySame,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			msg := token.MsgRevokeOperator{
 				ContractId: tc.contractID,
-				Holder:     tc.holder.String(),
-				Operator:   tc.operator.String(),
+				Holder:     tc.holder,
+				Operator:   tc.operator,
 			}
 
 			err := msg.ValidateBasic()
@@ -215,7 +221,7 @@ func TestMsgRevokeOperator(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, []sdk.AccAddress{tc.holder}, msg.GetSigners())
+			require.Equal(t, []sdk.AccAddress{sdk.MustAccAddressFromBech32(tc.holder)}, msg.GetSigners())
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR uses accAddress instead of address to compare in the `validatebasic` function in the collection & token modules.
Before this PR, it used case-sensitive comparison, thus it would occur a bug when `holder` and `operator` are the same but in different capitalization.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
