### PR TITLE
Compare the signer of the normal message and the signer of MsgExcute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/zkauth) [\#1280](https://github.com/Finschia/finschia-sdk/pull/1280) Fetch jwk considering goroutine exit
 
 ### Bug Fixes
+* (x/zkauth) [\#1291](https://github.com/Finschia/finschia-sdk/pull/1291) Compare the signer of the normal message and the signer of MsgExcute
 
 ### Removed
 

--- a/x/zkauth/keeper/keeper.go
+++ b/x/zkauth/keeper/keeper.go
@@ -52,12 +52,15 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-func (k Keeper) DispatchMsgs(ctx sdk.Context, msgs []sdk.Msg) ([][]byte, error) {
+func (k Keeper) DispatchMsgs(ctx sdk.Context, msgs []sdk.Msg, author sdk.AccAddress) ([][]byte, error) {
 	results := make([][]byte, 0, len(msgs))
 	for i, msg := range msgs {
 		signers := msg.GetSigners()
 		if len(signers) != 1 {
 			return nil, sdkerrors.ErrInvalidRequest.Wrap("authorization can be given to msg with only one signer")
+		}
+		if !author.Equals(signers[0]) {
+			return nil, sdkerrors.ErrUnauthorized.Wrapf("bad signer; expected %s, got %s", author, signers[0])
 		}
 		if err := msg.ValidateBasic(); err != nil {
 			return nil, err

--- a/x/zkauth/keeper/keeper_test.go
+++ b/x/zkauth/keeper/keeper_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -81,9 +82,10 @@ func TestDispatchMsgs(t *testing.T) {
 	testApp := testutil.ZkAuthKeeper(t)
 	app, k, ctx := testApp.Simapp, testApp.ZKAuthKeeper, testApp.Ctx
 
-	addrs := simapp.AddTestAddrs(app, ctx, 2, sdk.NewInt(100))
-	fromAddr := addrs[0]
-	toAddr := addrs[1]
+	addrs := simapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(100))
+	fromAddr := sdk.MustAccAddressFromBech32("link1f7j46mgxr3d5tgn3qsnn9ep8j77yr8w4ks0f3lpzz9rhnwja9vcqej33ld")
+	toAddr := addrs[0]
+	err := simapp.FundAccount(app, ctx, fromAddr, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100))))
 
 	newCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 5))
 
@@ -93,13 +95,27 @@ func TestDispatchMsgs(t *testing.T) {
 		ToAddress:   toAddr.String(),
 	}
 
-	zkAuthSig := types.ZKAuthSignature{}
+	testProofB64 := "eyJwaV9hIjpbIjM0MjM1MjQ3MjQzMDgyMDE5Mzc5NTQyMDUwMjA3MTMyNDg0MTg5OTQ5NjEzODk1OTcxODgxNjk1ODg4Njk5Mzg0MDgyMjI1NjE2MzAiLCI4OTQ1NzMxODIxOTg1NDU0MTcwNDA5MjQ2MjA4MDUxMzYwMzcxNzQ0NjUxOTYwNjg2MjQ5Njg1NjExMDI0NzQ4MjQ5MDk2NjUyNDAwIiwiMSJdLCJwaV9iIjpbWyIxNjE3NzgwNjczNzQ1MTg2MDY3NDk3NTAxNjI1MjExODM3NDU0NDU5NjE5NzcxMDAyNjYzMjAxMTg2MTg4OTM4NDkxMDc3MTU5ODUwIiwiMTAzODU2MDMyMjQzMDc2MDQxMjM5NjI2NzAyMzA3NDcxNDM2NDc2ODAxOTAwNTQzNzU3OTE5NjAxNjYwMTY2NzMyNTcwNjE5ODExNjgiXSxbIjYyMTE1NjA5NTUzMTE1NzgxNDcwMzEzMjAzMTE1MzAyODM5MzgwMDY5MTIyMjAwMTUwODM1MTIxODg2MDI5MzU0MjA4Mjk5MjY1NCIsIjEzODUwMDYzMTA5ODg2MTE3MDcwNzgzMzIxNDk1ODI4MzQ2MTg3ODQ3OTM3OTIyMDMyNTI2NzU3MTU2MDg0MjUzMTU4NTc0NjgyMTYyIl0sWyIxIiwiMCJdXSwicGlfYyI6WyIxMDE0MTM1NTQwNTE1MDg5MzQ1MjY3NTUwMTE4Mjk4MTY1MzY5NDI1MzM0MzMyMjAyNzM1OTgwNTU0NzYxODgyODE4NjU3NDU5MTA4IiwiNDkzMjY5MjI2OTcyOTIyNDQ4NjI1MDI0MDAyMjI4NTQ4NzE1MjYzNTkwNjAzMzA1ODYwNjgwMjI2Nzg4Nzg5NjE2MTU2NTM4MzYiLCIxIl19"
+	testProof, err := base64.StdEncoding.DecodeString(testProofB64)
+	require.NoError(t, err)
+
+	zkAuthSig := types.ZKAuthSignature{
+		ZkAuthInputs: &types.ZKAuthInputs{
+			ProofPoints:  testProof,
+			IssBase64:    "aHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29t",
+			HeaderBase64: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFkZjVlNzEwZWRmZWJlY2JlZmE5YTYxNDk1NjU0ZDAzYzBiOGVkZjgiLCJ0eXAiOiJKV1QifQ",
+			AddressSeed:  "16929294337693897740349056748881744503581363933815798702166939594477679063350",
+		},
+		MaxBlockHeight: 104,
+	}
 
 	msgs := types.NewMsgExecution([]sdk.Msg{&bankMsg}, zkAuthSig)
 
 	execMsgs, err := msgs.GetMessages()
 	require.NoError(t, err)
-	result, err := k.DispatchMsgs(ctx, execMsgs)
+	// zksigner is assumed to be one
+	zksigner := msgs.GetSigners()[0]
+	result, err := k.DispatchMsgs(ctx, execMsgs, zksigner)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/x/zkauth/keeper/keeper_test.go
+++ b/x/zkauth/keeper/keeper_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Finschia/finschia-sdk/simapp"
 	sdk "github.com/Finschia/finschia-sdk/types"
+	sdkerrors "github.com/Finschia/finschia-sdk/types/errors"
 	banktypes "github.com/Finschia/finschia-sdk/x/bank/types"
 	"github.com/Finschia/finschia-sdk/x/zkauth/testutil"
 	"github.com/Finschia/finschia-sdk/x/zkauth/types"
@@ -79,49 +80,67 @@ func TestFetchJwk(t *testing.T) {
 }
 
 func TestDispatchMsgs(t *testing.T) {
-	testApp := testutil.ZkAuthKeeper(t)
-	app, k, ctx := testApp.Simapp, testApp.ZKAuthKeeper, testApp.Ctx
-
-	addrs := simapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(100))
-	fromAddr := sdk.MustAccAddressFromBech32("link1f7j46mgxr3d5tgn3qsnn9ep8j77yr8w4ks0f3lpzz9rhnwja9vcqej33ld")
-	toAddr := addrs[0]
-	err := simapp.FundAccount(app, ctx, fromAddr, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100))))
-
-	newCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 5))
-
-	bankMsg := banktypes.MsgSend{
-		Amount:      newCoins,
-		FromAddress: fromAddr.String(),
-		ToAddress:   toAddr.String(),
-	}
-
-	testProofB64 := "eyJwaV9hIjpbIjM0MjM1MjQ3MjQzMDgyMDE5Mzc5NTQyMDUwMjA3MTMyNDg0MTg5OTQ5NjEzODk1OTcxODgxNjk1ODg4Njk5Mzg0MDgyMjI1NjE2MzAiLCI4OTQ1NzMxODIxOTg1NDU0MTcwNDA5MjQ2MjA4MDUxMzYwMzcxNzQ0NjUxOTYwNjg2MjQ5Njg1NjExMDI0NzQ4MjQ5MDk2NjUyNDAwIiwiMSJdLCJwaV9iIjpbWyIxNjE3NzgwNjczNzQ1MTg2MDY3NDk3NTAxNjI1MjExODM3NDU0NDU5NjE5NzcxMDAyNjYzMjAxMTg2MTg4OTM4NDkxMDc3MTU5ODUwIiwiMTAzODU2MDMyMjQzMDc2MDQxMjM5NjI2NzAyMzA3NDcxNDM2NDc2ODAxOTAwNTQzNzU3OTE5NjAxNjYwMTY2NzMyNTcwNjE5ODExNjgiXSxbIjYyMTE1NjA5NTUzMTE1NzgxNDcwMzEzMjAzMTE1MzAyODM5MzgwMDY5MTIyMjAwMTUwODM1MTIxODg2MDI5MzU0MjA4Mjk5MjY1NCIsIjEzODUwMDYzMTA5ODg2MTE3MDcwNzgzMzIxNDk1ODI4MzQ2MTg3ODQ3OTM3OTIyMDMyNTI2NzU3MTU2MDg0MjUzMTU4NTc0NjgyMTYyIl0sWyIxIiwiMCJdXSwicGlfYyI6WyIxMDE0MTM1NTQwNTE1MDg5MzQ1MjY3NTUwMTE4Mjk4MTY1MzY5NDI1MzM0MzMyMjAyNzM1OTgwNTU0NzYxODgyODE4NjU3NDU5MTA4IiwiNDkzMjY5MjI2OTcyOTIyNDQ4NjI1MDI0MDAyMjI4NTQ4NzE1MjYzNTkwNjAzMzA1ODYwNjgwMjI2Nzg4Nzg5NjE2MTU2NTM4MzYiLCIxIl19"
-	testProof, err := base64.StdEncoding.DecodeString(testProofB64)
-	require.NoError(t, err)
-
-	zkAuthSig := types.ZKAuthSignature{
-		ZkAuthInputs: &types.ZKAuthInputs{
-			ProofPoints:  testProof,
-			IssBase64:    "aHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29t",
-			HeaderBase64: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFkZjVlNzEwZWRmZWJlY2JlZmE5YTYxNDk1NjU0ZDAzYzBiOGVkZjgiLCJ0eXAiOiJKV1QifQ",
-			AddressSeed:  "16929294337693897740349056748881744503581363933815798702166939594477679063350",
+	testCases := map[string]struct {
+		from sdk.AccAddress
+		err  error
+	}{
+		"valid signer": {
+			from: sdk.MustAccAddressFromBech32("link1f7j46mgxr3d5tgn3qsnn9ep8j77yr8w4ks0f3lpzz9rhnwja9vcqej33ld"),
 		},
-		MaxBlockHeight: 104,
+		"invalid from": {
+			from: sdk.MustAccAddressFromBech32("link1apw93nvwxj3t4tvwf6h0n3t84lpyfmswzryxs0z49vlgr8r8xegs03lsnt"),
+			err:  sdkerrors.ErrUnauthorized,
+		},
 	}
 
-	msgs := types.NewMsgExecution([]sdk.Msg{&bankMsg}, zkAuthSig)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			testApp := testutil.ZkAuthKeeper(t)
+			app, k, ctx := testApp.Simapp, testApp.ZKAuthKeeper, testApp.Ctx
 
-	execMsgs, err := msgs.GetMessages()
-	require.NoError(t, err)
-	// zksigner is assumed to be one
-	zksigner := msgs.GetSigners()[0]
-	result, err := k.DispatchMsgs(ctx, execMsgs, zksigner)
+			addrs := simapp.AddTestAddrs(app, ctx, 1, sdk.NewInt(100))
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+			fromAddr := tc.from
+			toAddr := addrs[0]
+			err := simapp.FundAccount(app, ctx, fromAddr, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100))))
 
-	fromBalance := app.BankKeeper.GetBalance(ctx, fromAddr, "stake")
-	require.True(t, fromBalance.Equal(sdk.NewInt64Coin("stake", 95)))
-	toBalance := app.BankKeeper.GetBalance(ctx, toAddr, "stake")
-	require.True(t, toBalance.Equal(sdk.NewInt64Coin("stake", 105)))
+			newCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 5))
+
+			bankMsg := banktypes.MsgSend{
+				Amount:      newCoins,
+				FromAddress: fromAddr.String(),
+				ToAddress:   toAddr.String(),
+			}
+			testProofB64 := "eyJwaV9hIjpbIjM0MjM1MjQ3MjQzMDgyMDE5Mzc5NTQyMDUwMjA3MTMyNDg0MTg5OTQ5NjEzODk1OTcxODgxNjk1ODg4Njk5Mzg0MDgyMjI1NjE2MzAiLCI4OTQ1NzMxODIxOTg1NDU0MTcwNDA5MjQ2MjA4MDUxMzYwMzcxNzQ0NjUxOTYwNjg2MjQ5Njg1NjExMDI0NzQ4MjQ5MDk2NjUyNDAwIiwiMSJdLCJwaV9iIjpbWyIxNjE3NzgwNjczNzQ1MTg2MDY3NDk3NTAxNjI1MjExODM3NDU0NDU5NjE5NzcxMDAyNjYzMjAxMTg2MTg4OTM4NDkxMDc3MTU5ODUwIiwiMTAzODU2MDMyMjQzMDc2MDQxMjM5NjI2NzAyMzA3NDcxNDM2NDc2ODAxOTAwNTQzNzU3OTE5NjAxNjYwMTY2NzMyNTcwNjE5ODExNjgiXSxbIjYyMTE1NjA5NTUzMTE1NzgxNDcwMzEzMjAzMTE1MzAyODM5MzgwMDY5MTIyMjAwMTUwODM1MTIxODg2MDI5MzU0MjA4Mjk5MjY1NCIsIjEzODUwMDYzMTA5ODg2MTE3MDcwNzgzMzIxNDk1ODI4MzQ2MTg3ODQ3OTM3OTIyMDMyNTI2NzU3MTU2MDg0MjUzMTU4NTc0NjgyMTYyIl0sWyIxIiwiMCJdXSwicGlfYyI6WyIxMDE0MTM1NTQwNTE1MDg5MzQ1MjY3NTUwMTE4Mjk4MTY1MzY5NDI1MzM0MzMyMjAyNzM1OTgwNTU0NzYxODgyODE4NjU3NDU5MTA4IiwiNDkzMjY5MjI2OTcyOTIyNDQ4NjI1MDI0MDAyMjI4NTQ4NzE1MjYzNTkwNjAzMzA1ODYwNjgwMjI2Nzg4Nzg5NjE2MTU2NTM4MzYiLCIxIl19"
+			testProof, err := base64.StdEncoding.DecodeString(testProofB64)
+			require.NoError(t, err)
+
+			// The zkaddress generated from this signature is link1f7j46mgxr3d5tgn3qsnn9ep8j77yr8w4ks0f3lpzz9rhnwja9vcqej33ld.
+			zkAuthSig := types.ZKAuthSignature{
+				ZkAuthInputs: &types.ZKAuthInputs{
+					ProofPoints:  testProof,
+					IssBase64:    "aHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29t",
+					HeaderBase64: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFkZjVlNzEwZWRmZWJlY2JlZmE5YTYxNDk1NjU0ZDAzYzBiOGVkZjgiLCJ0eXAiOiJKV1QifQ",
+					AddressSeed:  "16929294337693897740349056748881744503581363933815798702166939594477679063350",
+				},
+				MaxBlockHeight: 104,
+			}
+			msgs := types.NewMsgExecution([]sdk.Msg{&bankMsg}, zkAuthSig)
+
+			execMsgs, err := msgs.GetMessages()
+			require.NoError(t, err)
+			// zksigner is assumed to be one
+			zksigner := msgs.GetSigners()[0]
+			_, err = k.DispatchMsgs(ctx, execMsgs, zksigner)
+			require.ErrorIs(t, err, tc.err)
+			if tc.err != nil {
+				return
+			}
+
+			fromBalance := app.BankKeeper.GetBalance(ctx, fromAddr, "stake")
+			require.True(t, fromBalance.Equal(sdk.NewInt64Coin("stake", 95)))
+			toBalance := app.BankKeeper.GetBalance(ctx, toAddr, "stake")
+			require.True(t, toBalance.Equal(sdk.NewInt64Coin("stake", 105)))
+		})
+	}
 }

--- a/x/zkauth/keeper/msg_server.go
+++ b/x/zkauth/keeper/msg_server.go
@@ -27,7 +27,10 @@ func (k msgServer) Execution(goCtx context.Context, msg *types.MsgExecution) (*t
 		return nil, err
 	}
 
-	results, err := k.DispatchMsgs(ctx, msgs)
+	// zksigner is assumed to be one
+	zksigner := msg.GetSigners()[0]
+
+	results, err := k.DispatchMsgs(ctx, msgs, zksigner)
 	if err != nil {
 		return nil, err
 	}

--- a/x/zkauth/keeper/msg_server_test.go
+++ b/x/zkauth/keeper/msg_server_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,8 +24,9 @@ func TestExecution(t *testing.T) {
 	msgServer, app, ctx := setupMsgServer(t)
 	newCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 5))
 	addrs := simapp.AddTestAddrs(app, ctx, 2, sdk.NewInt(100))
-	fromAddr := addrs[0]
-	toAddr := addrs[1]
+	fromAddr := sdk.MustAccAddressFromBech32("link1f7j46mgxr3d5tgn3qsnn9ep8j77yr8w4ks0f3lpzz9rhnwja9vcqej33ld")
+	toAddr := addrs[0]
+	err := simapp.FundAccount(app, ctx, fromAddr, sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100))))
 
 	bankMsg := banktypes.MsgSend{
 		Amount:      newCoins,
@@ -32,7 +34,19 @@ func TestExecution(t *testing.T) {
 		ToAddress:   toAddr.String(),
 	}
 
-	zkAuthSig := types.ZKAuthSignature{}
+	testProofB64 := "eyJwaV9hIjpbIjM0MjM1MjQ3MjQzMDgyMDE5Mzc5NTQyMDUwMjA3MTMyNDg0MTg5OTQ5NjEzODk1OTcxODgxNjk1ODg4Njk5Mzg0MDgyMjI1NjE2MzAiLCI4OTQ1NzMxODIxOTg1NDU0MTcwNDA5MjQ2MjA4MDUxMzYwMzcxNzQ0NjUxOTYwNjg2MjQ5Njg1NjExMDI0NzQ4MjQ5MDk2NjUyNDAwIiwiMSJdLCJwaV9iIjpbWyIxNjE3NzgwNjczNzQ1MTg2MDY3NDk3NTAxNjI1MjExODM3NDU0NDU5NjE5NzcxMDAyNjYzMjAxMTg2MTg4OTM4NDkxMDc3MTU5ODUwIiwiMTAzODU2MDMyMjQzMDc2MDQxMjM5NjI2NzAyMzA3NDcxNDM2NDc2ODAxOTAwNTQzNzU3OTE5NjAxNjYwMTY2NzMyNTcwNjE5ODExNjgiXSxbIjYyMTE1NjA5NTUzMTE1NzgxNDcwMzEzMjAzMTE1MzAyODM5MzgwMDY5MTIyMjAwMTUwODM1MTIxODg2MDI5MzU0MjA4Mjk5MjY1NCIsIjEzODUwMDYzMTA5ODg2MTE3MDcwNzgzMzIxNDk1ODI4MzQ2MTg3ODQ3OTM3OTIyMDMyNTI2NzU3MTU2MDg0MjUzMTU4NTc0NjgyMTYyIl0sWyIxIiwiMCJdXSwicGlfYyI6WyIxMDE0MTM1NTQwNTE1MDg5MzQ1MjY3NTUwMTE4Mjk4MTY1MzY5NDI1MzM0MzMyMjAyNzM1OTgwNTU0NzYxODgyODE4NjU3NDU5MTA4IiwiNDkzMjY5MjI2OTcyOTIyNDQ4NjI1MDI0MDAyMjI4NTQ4NzE1MjYzNTkwNjAzMzA1ODYwNjgwMjI2Nzg4Nzg5NjE2MTU2NTM4MzYiLCIxIl19"
+	testProof, err := base64.StdEncoding.DecodeString(testProofB64)
+	require.NoError(t, err)
+
+	zkAuthSig := types.ZKAuthSignature{
+		ZkAuthInputs: &types.ZKAuthInputs{
+			ProofPoints:  testProof,
+			IssBase64:    "aHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29t",
+			HeaderBase64: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFkZjVlNzEwZWRmZWJlY2JlZmE5YTYxNDk1NjU0ZDAzYzBiOGVkZjgiLCJ0eXAiOiJKV1QifQ",
+			AddressSeed:  "16929294337693897740349056748881744503581363933815798702166939594477679063350",
+		},
+		MaxBlockHeight: 104,
+	}
 
 	msgs := types.NewMsgExecution([]sdk.Msg{&bankMsg}, zkAuthSig)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, msgs signer validation is not performed when dispatching msgs of MsgExcute.
This leads to serious problems such as fraudulent transfers.

This can be prevented by making sure that the signer of the msg executed when dispatching msg is the signer of MsgExcute.
We will have to discuss later whether this modification is sufficient.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
