### PR TITLE
fix: reject NFT coins on FT APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/foundation) [\#1277](https://github.com/Finschia/finschia-sdk/pull/1277) add init logic of foundation module accounts to InitGenesis in order to eliminate potential panic
 * (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 * (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
+* (x/collection) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) reject NFT coins on FT APIs
 
 ### Removed
 

--- a/x/collection/msgs.go
+++ b/x/collection/msgs.go
@@ -46,8 +46,8 @@ func validateAmount(amount sdk.Int) error {
 }
 
 // deprecated
-func validateCoins(amount []Coin) error {
-	return validateCoinsWithIDValidator(amount, ValidateTokenID)
+func validateFTCoins(amount []Coin) error {
+	return validateCoinsWithIDValidator(amount, ValidateFTID)
 }
 
 // deprecated
@@ -247,7 +247,7 @@ func (m MsgSendFT) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid to address: %s", m.To)
 	}
 
-	if err := validateCoins(m.Amount); err != nil {
+	if err := validateFTCoins(m.Amount); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (m MsgOperatorSendFT) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid to address: %s", m.To)
 	}
 
-	if err := validateCoins(m.Amount); err != nil {
+	if err := validateFTCoins(m.Amount); err != nil {
 		return err
 	}
 
@@ -675,7 +675,7 @@ func (m MsgMintFT) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid to address: %s", m.To)
 	}
 
-	if err := validateCoins(m.Amount); err != nil {
+	if err := validateFTCoins(m.Amount); err != nil {
 		return err
 	}
 
@@ -775,7 +775,7 @@ func (m MsgBurnFT) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid from address: %s", m.From)
 	}
 
-	if err := validateCoins(m.Amount); err != nil {
+	if err := validateFTCoins(m.Amount); err != nil {
 		return err
 	}
 
@@ -818,7 +818,7 @@ func (m MsgOperatorBurnFT) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid from address: %s", m.From)
 	}
 
-	if err := validateCoins(m.Amount); err != nil {
+	if err := validateFTCoins(m.Amount); err != nil {
 		return err
 	}
 

--- a/x/collection/msgs_test.go
+++ b/x/collection/msgs_test.go
@@ -1064,7 +1064,7 @@ func TestMsgBurnFT(t *testing.T) {
 			amount: []collection.Coin{
 				collection.NewNFTCoin("deadbeef", 42),
 			},
-			err: collection.ErrInvalidAmount,
+			err: collection.ErrInvalidTokenID,
 		},
 	}
 
@@ -1153,7 +1153,7 @@ func TestMsgOperatorBurnFT(t *testing.T) {
 			amount: []collection.Coin{
 				collection.NewNFTCoin("deadbeef", 42),
 			},
-			err: collection.ErrInvalidAmount,
+			err: collection.ErrInvalidTokenID,
 		},
 	}
 

--- a/x/collection/msgs_test.go
+++ b/x/collection/msgs_test.go
@@ -85,6 +85,15 @@ func TestMsgSendFT(t *testing.T) {
 			}},
 			err: collection.ErrInvalidTokenID,
 		},
+		"nft id": {
+			contractID: "deadbeef",
+			from:       addrs[0],
+			to:         addrs[1],
+			amount: []collection.Coin{
+				collection.NewNFTCoin("deadbeef", 42),
+			},
+			err: collection.ErrInvalidTokenID,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -183,6 +192,16 @@ func TestMsgOperatorSendFT(t *testing.T) {
 			amount: []collection.Coin{{
 				Amount: sdk.OneInt(),
 			}},
+			err: collection.ErrInvalidTokenID,
+		},
+		"nft id": {
+			contractID: "deadbeef",
+			operator:   addrs[0],
+			from:       addrs[1],
+			to:         addrs[2],
+			amount: []collection.Coin{
+				collection.NewNFTCoin("deadbeef", 42),
+			},
 			err: collection.ErrInvalidTokenID,
 		},
 	}
@@ -848,6 +867,15 @@ func TestMsgMintFT(t *testing.T) {
 			}},
 			err: collection.ErrInvalidTokenID,
 		},
+		"nft id": {
+			contractID: contractID,
+			operator:   addrs[0],
+			to:         addrs[1],
+			amount: []collection.Coin{
+				collection.NewNFTCoin("deadbeef", 42),
+			},
+			err: collection.ErrInvalidTokenID,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1030,6 +1058,14 @@ func TestMsgBurnFT(t *testing.T) {
 			}},
 			err: collection.ErrInvalidAmount,
 		},
+		"nft id": {
+			contractID: "deadbeef",
+			from:       addrs[0],
+			amount: []collection.Coin{
+				collection.NewNFTCoin("deadbeef", 42),
+			},
+			err: collection.ErrInvalidAmount,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1108,6 +1144,15 @@ func TestMsgOperatorBurnFT(t *testing.T) {
 				TokenId: collection.NewFTID("00bab10c"),
 				Amount:  sdk.ZeroInt(),
 			}},
+			err: collection.ErrInvalidAmount,
+		},
+		"nft id": {
+			contractID: "deadbeef",
+			grantee:    addrs[0],
+			from:       addrs[1],
+			amount: []collection.Coin{
+				collection.NewNFTCoin("deadbeef", 42),
+			},
 			err: collection.ErrInvalidAmount,
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch renames `validateCoins()` into `validateFTCoins()` and update its logic to reject valid _NFT_ coins.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`validateCoins()` are only used on FT APIs, but does not reject NFT coins. This patch addresses the problem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
