### PR TITLE
fix: Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 * (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
 * (x/collection) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) reject NFT coins on FT APIs
+* (x/staking) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 * (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
 * (x/collection) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) reject NFT coins on FT APIs
-* (x/staking) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)
+* (x/staking) [\#1301](https://github.com/Finschia/finschia-sdk/pull/1301) Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)
 
 ### Removed
 

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -375,9 +375,21 @@ func (k Keeper) DeleteValidatorQueue(ctx sdk.Context, val types.Validator) {
 	addrs := k.GetUnbondingValidators(ctx, val.UnbondingTime, val.UnbondingHeight)
 	newAddrs := []string{}
 
+	// since address string may change due to Bech32 prefix change, we parse the addresses into bytes
+	// format for normalization
+	deletingAddr, err := sdk.ValAddressFromBech32(val.OperatorAddress)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, addr := range addrs {
-		if addr != val.OperatorAddress {
-			newAddrs = append(newAddrs, addr)
+		storedAddr, err := sdk.ValAddressFromBech32(addr)
+		if err != nil {
+			// even if we don't panic here, it will panic in UnbondAllMatureValidators at unbond time
+			panic(err)
+		}
+		if !storedAddr.Equals(deletingAddr) {
+			newAddrs = append(newAddrs, storedAddr.String())
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cherry-pick of:
- cosmos/cosmos-sdk#12303

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
