### PR TITLE
fix: fetch a failed proposal tally from proposal.FinalTallyResult in the gprc query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 * (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
 * (x/collection) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) reject NFT coins on FT APIs
+* (x/gov) [\#1304](https://github.com/Finschia/finschia-sdk/pull/1304) fetch a failed proposal tally from proposal.FinalTallyResult in the gprc query
 
 ### Removed
 

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -264,8 +264,13 @@ func (q Keeper) TallyResult(c context.Context, req *types.QueryTallyResultReques
 	case proposal.Status == types.StatusDepositPeriod:
 		tallyResult = types.EmptyTallyResult()
 
+<<<<<<< HEAD
 	case proposal.Status == types.StatusPassed || proposal.Status == types.StatusRejected:
 		tallyResult = proposal.FinalTallyResult
+=======
+	case proposal.Status == v1.StatusPassed || proposal.Status == v1.StatusRejected || proposal.Status == v1.StatusFailed:
+		tallyResult = *proposal.FinalTallyResult
+>>>>>>> d961aef76b (fix(x/gov): grpc query tally for failed proposal (#19725))
 
 	default:
 		// proposal is in voting period

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -264,13 +264,8 @@ func (q Keeper) TallyResult(c context.Context, req *types.QueryTallyResultReques
 	case proposal.Status == types.StatusDepositPeriod:
 		tallyResult = types.EmptyTallyResult()
 
-<<<<<<< HEAD
-	case proposal.Status == types.StatusPassed || proposal.Status == types.StatusRejected:
+	case proposal.Status == types.StatusPassed || proposal.Status == types.StatusRejected || proposal.Status == types.StatusFailed:
 		tallyResult = proposal.FinalTallyResult
-=======
-	case proposal.Status == v1.StatusPassed || proposal.Status == v1.StatusRejected || proposal.Status == v1.StatusFailed:
-		tallyResult = *proposal.FinalTallyResult
->>>>>>> d961aef76b (fix(x/gov): grpc query tally for failed proposal (#19725))
 
 	default:
 		// proposal is in voting period

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -798,6 +798,48 @@ func (suite *KeeperTestSuite) TestGRPCQueryTally() {
 			},
 			true,
 		},
+		{
+			"proposal status failed",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:     1,
+					Status: v1.StatusFailed,
+					FinalTallyResult: &v1.TallyResult{
+						YesCount:         "4",
+						AbstainCount:     "1",
+						NoCount:          "0",
+						NoWithVetoCount:  "0",
+						OptionOneCount:   "4",
+						OptionTwoCount:   "1",
+						OptionThreeCount: "0",
+						OptionFourCount:  "0",
+						SpamCount:        "0",
+					},
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1.TallyResult{
+					YesCount:         "4",
+					AbstainCount:     "1",
+					NoCount:          "0",
+					NoWithVetoCount:  "0",
+					OptionOneCount:   "4",
+					OptionTwoCount:   "1",
+					OptionThreeCount: "0",
+					OptionFourCount:  "0",
+					SpamCount:        "0",
+				}
+			},
+			true,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -811,7 +853,315 @@ func (suite *KeeperTestSuite) TestGRPCQueryTally() {
 				suite.Require().Equal(expRes.String(), tally.String())
 			} else {
 				suite.Require().Error(err)
+<<<<<<< HEAD
 				suite.Require().Nil(tally)
+=======
+				suite.Require().Nil(tallyRes)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestLegacyGRPCQueryTallyResult() {
+	suite.reset()
+	queryClient := suite.legacyQueryClient
+
+	var (
+		req      *v1beta1.QueryTallyResultRequest
+		expTally *v1beta1.TallyResult
+	)
+
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"empty request",
+			func() {
+				req = &v1beta1.QueryTallyResultRequest{}
+			},
+			false,
+		},
+		{
+			"non existing proposal request",
+			func() {
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: 2}
+			},
+			false,
+		},
+		{
+			"zero proposal id request",
+			func() {
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: 0}
+			},
+			false,
+		},
+		{
+			"valid request with proposal status passed",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:     1,
+					Status: v1.StatusPassed,
+					FinalTallyResult: &v1.TallyResult{
+						YesCount:        "4",
+						AbstainCount:    "1",
+						NoCount:         "0",
+						NoWithVetoCount: "0",
+						SpamCount:       "0",
+					},
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1beta1.TallyResult{
+					Yes:        math.NewInt(4),
+					Abstain:    math.NewInt(1),
+					No:         math.NewInt(0),
+					NoWithVeto: math.NewInt(0),
+				}
+			},
+			true,
+		},
+		{
+			"proposal status deposit",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:              1,
+					Status:          v1.StatusDepositPeriod,
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1beta1.TallyResult{
+					Yes:        math.NewInt(0),
+					Abstain:    math.NewInt(0),
+					No:         math.NewInt(0),
+					NoWithVeto: math.NewInt(0),
+				}
+			},
+			true,
+		},
+		{
+			"proposal is in voting period",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:              1,
+					Status:          v1.StatusVotingPeriod,
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1beta1.TallyResult{
+					Yes:        math.NewInt(0),
+					Abstain:    math.NewInt(0),
+					No:         math.NewInt(0),
+					NoWithVeto: math.NewInt(0),
+				}
+			},
+			true,
+		},
+		{
+			"proposal status failed",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:     1,
+					Status: v1.StatusFailed,
+					FinalTallyResult: &v1.TallyResult{
+						YesCount:        "4",
+						AbstainCount:    "1",
+						NoCount:         "0",
+						NoWithVetoCount: "0",
+						SpamCount:       "0",
+					},
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1beta1.TallyResult{
+					Yes:        math.NewInt(4),
+					Abstain:    math.NewInt(1),
+					No:         math.NewInt(0),
+					NoWithVeto: math.NewInt(0),
+				}
+			},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			if tc.malleate != nil {
+				tc.malleate()
+			}
+
+			tallyRes, err := queryClient.TallyResult(gocontext.Background(), req)
+
+			if tc.expPass {
+				suite.Require().NoError(err)
+				suite.Require().NotEmpty(tallyRes.Tally.String())
+				suite.Require().Equal(expTally.String(), tallyRes.Tally.String())
+			} else {
+				suite.Require().Error(err)
+				suite.Require().Nil(tallyRes)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestProposalVoteOptions() {
+	suite.reset()
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		req      *v1.QueryProposalVoteOptionsRequest
+		expResp  *v1.QueryProposalVoteOptionsResponse
+		errStr   string
+	}{
+		{
+			name:   "invalid proposal id",
+			req:    &v1.QueryProposalVoteOptionsRequest{},
+			errStr: "proposal id can not be 0",
+		},
+		{
+			name:   "proposal not found",
+			req:    &v1.QueryProposalVoteOptionsRequest{ProposalId: 1},
+			errStr: "proposal 1 doesn't exist",
+		},
+		{
+			name: "non multiple choice proposal",
+			malleate: func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:              1,
+					Status:          v1.StatusVotingPeriod,
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+					ProposalType:    v1.ProposalType_PROPOSAL_TYPE_STANDARD,
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+			},
+			req: &v1.QueryProposalVoteOptionsRequest{ProposalId: 1},
+			expResp: &v1.QueryProposalVoteOptionsResponse{
+				VoteOptions: &v1.ProposalVoteOptions{
+					OptionOne:   "yes",
+					OptionTwo:   "abstain",
+					OptionThree: "no",
+					OptionFour:  "no_with_veto",
+					OptionSpam:  "spam",
+				},
+			},
+		},
+		{
+			name: "invalid multiple choice proposal",
+			req:  &v1.QueryProposalVoteOptionsRequest{ProposalId: 2},
+			malleate: func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:              2,
+					Status:          v1.StatusVotingPeriod,
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+					ProposalType:    v1.ProposalType_PROPOSAL_TYPE_MULTIPLE_CHOICE,
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				// multiple choice proposal, but no vote options set
+				// because the query does not check the proposal type,
+				// it falls back to the default vote options
+			},
+			expResp: &v1.QueryProposalVoteOptionsResponse{
+				VoteOptions: &v1.ProposalVoteOptions{
+					OptionOne:   "yes",
+					OptionTwo:   "abstain",
+					OptionThree: "no",
+					OptionFour:  "no_with_veto",
+					OptionSpam:  "spam",
+				},
+			},
+		},
+		{
+			name: "multiple choice proposal",
+			req:  &v1.QueryProposalVoteOptionsRequest{ProposalId: 3},
+			malleate: func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:              3,
+					Status:          v1.StatusVotingPeriod,
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+					ProposalType:    v1.ProposalType_PROPOSAL_TYPE_MULTIPLE_CHOICE,
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+				err = suite.govKeeper.ProposalVoteOptions.Set(suite.ctx, proposal.Id, v1.ProposalVoteOptions{
+					OptionOne:   "Vote for @tac0turle",
+					OptionTwo:   "Vote for @facudomedica",
+					OptionThree: "Vote for @alexanderbez",
+				})
+				suite.Require().NoError(err)
+			},
+			expResp: &v1.QueryProposalVoteOptionsResponse{
+				VoteOptions: &v1.ProposalVoteOptions{
+					OptionOne:   "Vote for @tac0turle",
+					OptionTwo:   "Vote for @facudomedica",
+					OptionThree: "Vote for @alexanderbez",
+					OptionSpam:  "spam",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			if tc.malleate != nil {
+				tc.malleate()
+			}
+
+			resp, err := suite.queryClient.ProposalVoteOptions(suite.ctx, tc.req)
+			if tc.errStr != "" {
+				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.errStr)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expResp, resp)
+>>>>>>> d961aef76b (fix(x/gov): grpc query tally for failed proposal (#19725))
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The TallyResult() is used to fetch the tally result from a proposal, in which the case when a proposal fails does not provide the correct information as this case has been branched into the default case.
This pr cherry-pick the following pr:
- https://github.com/cosmos/cosmos-sdk/pull/19725

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
