### PR TITLE
fix: add validation for potential slashing evasion during re-delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/collection, x/token) [\#1288](https://github.com/Finschia/finschia-sdk/pull/1288) use accAddress to compare in validatebasic function in collection & token modules
 * (x/collection) [\#1268](https://github.com/Finschia/finschia-sdk/pull/1268) export x/collection params into genesis
 * (x/collection) [\#1294](https://github.com/Finschia/finschia-sdk/pull/1294) reject NFT coins on FT APIs
+* (x/staking) [\#1306](https://github.com/Finschia/finschia-sdk/pull/1306) add validation for potential slashing evasion during re-delegation
 
 ### Removed
 

--- a/x/slashing/keeper/slash_redelegation_test.go
+++ b/x/slashing/keeper/slash_redelegation_test.go
@@ -1,0 +1,147 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Finschia/finschia-sdk/crypto/keys/secp256k1"
+	"github.com/Finschia/finschia-sdk/simapp"
+	sdk "github.com/Finschia/finschia-sdk/types"
+	bankkeeper "github.com/Finschia/finschia-sdk/x/bank/keeper"
+	banktestutil "github.com/Finschia/finschia-sdk/x/bank/testutil"
+	distributionkeeper "github.com/Finschia/finschia-sdk/x/distribution/keeper"
+	stakingkeeper "github.com/Finschia/finschia-sdk/x/staking/keeper"
+	stakingtypes "github.com/Finschia/finschia-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestSlashRedelegation(t *testing.T) {
+	// setting up
+	app := simapp.Setup(false)
+
+	stakingKeeper := app.StakingKeeper
+	bankKeeper := app.BankKeeper
+	slashKeeper := app.SlashingKeeper
+	distrKeeper := app.DistrKeeper
+
+	// get sdk context, staking msg server and bond denom
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: app.LastBlockHeight() + 1})
+	stakingMsgServer := stakingkeeper.NewMsgServerImpl(stakingKeeper)
+	bondDenom := stakingKeeper.BondDenom(ctx)
+
+	// evilVal will be slashed, goodVal won't be slashed
+	evilValPubKey := secp256k1.GenPrivKey().PubKey()
+	goodValPubKey := secp256k1.GenPrivKey().PubKey()
+
+	// both test acc 1 and 2 delegated to evil val, both acc should be slashed when evil val is slashed
+	// test acc 1 use the "undelegation after redelegation" trick (redelegate to good val and then undelegate) to avoid slashing
+	// test acc 2 only undelegate from evil val
+	testAcc1 := sdk.AccAddress([]byte("addr1_______________"))
+	testAcc2 := sdk.AccAddress([]byte("addr2_______________"))
+
+	// fund acc 1 and acc 2
+	testCoins := sdk.NewCoins(sdk.NewCoin(bondDenom, stakingKeeper.TokensFromConsensusPower(ctx, 10)))
+	banktestutil.FundAccount(bankKeeper, ctx, testAcc1, testCoins)
+	banktestutil.FundAccount(bankKeeper, ctx, testAcc2, testCoins)
+
+	balance1Before := bankKeeper.GetBalance(ctx, testAcc1, bondDenom)
+	balance2Before := bankKeeper.GetBalance(ctx, testAcc2, bondDenom)
+
+	// assert acc 1 and acc 2 balance
+	require.Equal(t, balance1Before.Amount.String(), testCoins[0].Amount.String())
+	require.Equal(t, balance2Before.Amount.String(), testCoins[0].Amount.String())
+
+	// creating evil val
+	evilValAddr := sdk.ValAddress(evilValPubKey.Address())
+	banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(evilValAddr), testCoins)
+	createValMsg1, _ := stakingtypes.NewMsgCreateValidator(
+		evilValAddr, evilValPubKey, testCoins[0], stakingtypes.Description{Details: "test"}, stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0)), sdk.OneInt())
+	_, err := stakingMsgServer.CreateValidator(sdk.WrapSDKContext(ctx), createValMsg1)
+	require.NoError(t, err)
+
+	// creating good val
+	goodValAddr := sdk.ValAddress(goodValPubKey.Address())
+	banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(goodValAddr), testCoins)
+	createValMsg2, _ := stakingtypes.NewMsgCreateValidator(
+		goodValAddr, goodValPubKey, testCoins[0], stakingtypes.Description{Details: "test"}, stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0)), sdk.OneInt())
+	_, err = stakingMsgServer.CreateValidator(sdk.WrapSDKContext(ctx), createValMsg2)
+	require.NoError(t, err)
+
+	// next block, commit height 1, move to height 2
+	// acc 1 and acc 2 delegate to evil val
+	ctx = app.NextBlock(ctx, time.Duration(1))
+	require.NoError(t, err)
+
+	// Acc 2 delegate
+	delMsg := stakingtypes.NewMsgDelegate(testAcc2, evilValAddr, testCoins[0])
+	_, err = stakingMsgServer.Delegate(sdk.WrapSDKContext(ctx), delMsg)
+	require.NoError(t, err)
+
+	// Acc 1 delegate
+	delMsg = stakingtypes.NewMsgDelegate(testAcc1, evilValAddr, testCoins[0])
+	_, err = stakingMsgServer.Delegate(sdk.WrapSDKContext(ctx), delMsg)
+	require.NoError(t, err)
+
+	// next block, commit height 2, move to height 3
+	// with the new delegations, evil val increases in voting power and commit byzantine behaviour at height 3 consensus
+	// at the same time, acc 1 and acc 2 withdraw delegation from evil val
+	ctx = app.NextBlock(ctx, time.Duration(1))
+	require.NoError(t, err)
+
+	evilVal, found := stakingKeeper.GetValidator(ctx, evilValAddr)
+	require.True(t, found)
+
+	evilPower := stakingKeeper.TokensToConsensusPower(ctx, evilVal.Tokens)
+
+	// Acc 1 redelegate from evil val to good val
+	redelMsg := stakingtypes.NewMsgBeginRedelegate(testAcc1, evilValAddr, goodValAddr, testCoins[0])
+	_, err = stakingMsgServer.BeginRedelegate(sdk.WrapSDKContext(ctx), redelMsg)
+	require.NoError(t, err)
+
+	// Acc 1 undelegate from good val
+	undelMsg := stakingtypes.NewMsgUndelegate(testAcc1, goodValAddr, testCoins[0])
+	_, err = stakingMsgServer.Undelegate(sdk.WrapSDKContext(ctx), undelMsg)
+	require.NoError(t, err)
+
+	// Acc 2 undelegate from evil val
+	undelMsg = stakingtypes.NewMsgUndelegate(testAcc2, evilValAddr, testCoins[0])
+	_, err = stakingMsgServer.Undelegate(sdk.WrapSDKContext(ctx), undelMsg)
+	require.NoError(t, err)
+
+	// next block, commit height 3, move to height 4
+	// Slash evil val for byzantine behaviour at height 3 consensus,
+	// at which acc 1 and acc 2 still contributed to evil val voting power
+	// even tho they undelegate at block 3, the valset update is applied after commited block 3 when height 3 consensus already passes
+	ctx = app.NextBlock(ctx, time.Duration(1))
+	require.NoError(t, err)
+
+	// slash evil val with slash factor = 0.9, leaving only 10% of stake after slashing
+	evilVal, _ = stakingKeeper.GetValidator(ctx, evilValAddr)
+	evilValConsAddr, err := evilVal.GetConsAddr()
+	require.NoError(t, err)
+
+	slashKeeper.Slash(ctx, evilValConsAddr, sdk.MustNewDecFromStr("0.9"), evilPower, 3)
+
+	// assert invariant to make sure we conduct slashing correctly
+	_, stop := stakingkeeper.AllInvariants(stakingKeeper)(ctx)
+	require.False(t, stop)
+
+	_, stop = bankkeeper.AllInvariants(bankKeeper)(ctx)
+	require.False(t, stop)
+
+	_, stop = distributionkeeper.AllInvariants(distrKeeper)(ctx)
+	require.False(t, stop)
+
+	// one eternity later
+	ctx = app.NextBlock(ctx, time.Duration(1000000000000000000))
+	ctx = app.NextBlock(ctx, time.Duration(1))
+
+	// confirm that account 1 and account 2 has been slashed, and the slash amount is correct
+	balance1AfterSlashing := bankKeeper.GetBalance(ctx, testAcc1, bondDenom)
+	balance2AfterSlashing := bankKeeper.GetBalance(ctx, testAcc2, bondDenom)
+
+	require.Equal(t, balance1AfterSlashing.Amount.Mul(sdk.NewIntFromUint64(10)).String(), balance1Before.Amount.String())
+	require.Equal(t, balance2AfterSlashing.Amount.Mul(sdk.NewIntFromUint64(10)).String(), balance2Before.Amount.String())
+}

--- a/x/slashing/keeper/slash_redelegation_test.go
+++ b/x/slashing/keeper/slash_redelegation_test.go
@@ -43,8 +43,10 @@ func TestSlashRedelegation(t *testing.T) {
 
 	// fund acc 1 and acc 2
 	testCoins := sdk.NewCoins(sdk.NewCoin(bondDenom, stakingKeeper.TokensFromConsensusPower(ctx, 10)))
-	banktestutil.FundAccount(bankKeeper, ctx, testAcc1, testCoins)
-	banktestutil.FundAccount(bankKeeper, ctx, testAcc2, testCoins)
+	err := banktestutil.FundAccount(bankKeeper, ctx, testAcc1, testCoins)
+	require.NoError(t, err)
+	err = banktestutil.FundAccount(bankKeeper, ctx, testAcc2, testCoins)
+	require.NoError(t, err)
 
 	balance1Before := bankKeeper.GetBalance(ctx, testAcc1, bondDenom)
 	balance2Before := bankKeeper.GetBalance(ctx, testAcc2, bondDenom)
@@ -55,15 +57,17 @@ func TestSlashRedelegation(t *testing.T) {
 
 	// creating evil val
 	evilValAddr := sdk.ValAddress(evilValPubKey.Address())
-	banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(evilValAddr), testCoins)
+	err = banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(evilValAddr), testCoins)
+	require.NoError(t, err)
 	createValMsg1, _ := stakingtypes.NewMsgCreateValidator(
 		evilValAddr, evilValPubKey, testCoins[0], stakingtypes.Description{Details: "test"}, stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0)), sdk.OneInt())
-	_, err := stakingMsgServer.CreateValidator(sdk.WrapSDKContext(ctx), createValMsg1)
+	_, err = stakingMsgServer.CreateValidator(sdk.WrapSDKContext(ctx), createValMsg1)
 	require.NoError(t, err)
 
 	// creating good val
 	goodValAddr := sdk.ValAddress(goodValPubKey.Address())
-	banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(goodValAddr), testCoins)
+	err = banktestutil.FundAccount(bankKeeper, ctx, sdk.AccAddress(goodValAddr), testCoins)
+	require.NoError(t, err)
 	createValMsg2, _ := stakingtypes.NewMsgCreateValidator(
 		goodValAddr, goodValPubKey, testCoins[0], stakingtypes.Description{Details: "test"}, stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0)), sdk.OneInt())
 	_, err = stakingMsgServer.CreateValidator(sdk.WrapSDKContext(ctx), createValMsg2)
@@ -85,7 +89,7 @@ func TestSlashRedelegation(t *testing.T) {
 	require.NoError(t, err)
 
 	// next block, commit height 2, move to height 3
-	// with the new delegations, evil val increases in voting power and commit byzantine behaviour at height 3 consensus
+	// with the new delegations, evil val increases in voting power and commit byzantine behavior at height 3 consensus
 	// at the same time, acc 1 and acc 2 withdraw delegation from evil val
 	ctx = app.NextBlock(ctx, time.Duration(1))
 	require.NoError(t, err)
@@ -111,9 +115,9 @@ func TestSlashRedelegation(t *testing.T) {
 	require.NoError(t, err)
 
 	// next block, commit height 3, move to height 4
-	// Slash evil val for byzantine behaviour at height 3 consensus,
+	// Slash evil val for byzantine behavior at height 3 consensus,
 	// at which acc 1 and acc 2 still contributed to evil val voting power
-	// even tho they undelegate at block 3, the valset update is applied after commited block 3 when height 3 consensus already passes
+	// even tho they undelegate at block 3, the valset update is applied after committed block 3 when height 3 consensus already passes
 	ctx = app.NextBlock(ctx, time.Duration(1))
 	require.NoError(t, err)
 

--- a/x/slashing/keeper/slash_redelegation_test.go
+++ b/x/slashing/keeper/slash_redelegation_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
 	"github.com/Finschia/finschia-sdk/crypto/keys/secp256k1"
 	"github.com/Finschia/finschia-sdk/simapp"
 	sdk "github.com/Finschia/finschia-sdk/types"
@@ -12,9 +15,6 @@ import (
 	distributionkeeper "github.com/Finschia/finschia-sdk/x/distribution/keeper"
 	stakingkeeper "github.com/Finschia/finschia-sdk/x/staking/keeper"
 	stakingtypes "github.com/Finschia/finschia-sdk/x/staking/types"
-	"github.com/stretchr/testify/require"
-
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func TestSlashRedelegation(t *testing.T) {

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -248,9 +248,46 @@ func (k Keeper) SlashRedelegation(ctx sdk.Context, srcValidator types.Validator,
 		slashAmount := slashAmountDec.TruncateInt()
 		totalSlashAmount = totalSlashAmount.Add(slashAmount)
 
+		validatorDstAddress, err := sdk.ValAddressFromBech32(redelegation.ValidatorDstAddress)
+		if err != nil {
+			panic(err)
+		}
+		// Handle undelegation after redelegation
+		// Prioritize slashing unbondingDelegation than delegation
+		unbondingDelegation, found := k.GetUnbondingDelegation(ctx, sdk.MustAccAddressFromBech32(redelegation.DelegatorAddress), validatorDstAddress)
+		if found {
+			for i, entry := range unbondingDelegation.Entries {
+				// slash with the amount of `slashAmount` if possible, else slash all unbonding token
+				unbondingSlashAmount := sdk.MinInt(slashAmount, entry.Balance)
+
+				switch {
+				// There's no token to slash
+				case unbondingSlashAmount.IsZero():
+					continue
+				// If unbonding started before this height, stake didn't contribute to infraction
+				case entry.CreationHeight < infractionHeight:
+					continue
+				// Unbonding delegation no longer eligible for slashing, skip it
+				case entry.IsMature(now):
+					continue
+				// Slash the unbonding delegation
+				default:
+					// update remaining slashAmount
+					slashAmount = slashAmount.Sub(unbondingSlashAmount)
+
+					notBondedBurnedAmount = notBondedBurnedAmount.Add(unbondingSlashAmount)
+					entry.Balance = entry.Balance.Sub(unbondingSlashAmount)
+					unbondingDelegation.Entries[i] = entry
+					k.SetUnbondingDelegation(ctx, unbondingDelegation)
+				}
+			}
+		}
+
+		// Slash the moved delegation
+
 		// Unbond from target validator
 		sharesToUnbond := slashFactor.Mul(entry.SharesDst)
-		if sharesToUnbond.IsZero() {
+		if sharesToUnbond.IsZero() || slashAmount.IsZero() {
 			continue
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #XXXX

According to the [GHSA-86h5-xcpx-cfqc](https://github.com/advisories/GHSA-86h5-xcpx-cfqc), an issue was identified in the slashing mechanism that may allow for the evasion of slashing penalties during a slashing event. If a delegation contributed to the byzantine behavior of a validator and the validator has not yet been slashed, it may be possible for that delegation to evade a pending slashing penalty through re-delegation behavior. 

Additional validation logic was added to restrict this behavior in below commit in cosmos-sdk.
https://github.com/cosmos/cosmos-sdk/commit/d1b5b0c5ae2c51206cc1849e09e4d59986742cc3

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
