### PR TITLE
fix: app-hash mismatch if upgrade migration commit is interrupted(backport cosmos/cosmos-sdk#13530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Breaking Changes
 * (consensus) [\#1178](https://github.com/Finschia/finschia-sdk/pull/1178) change the consensus from Ostracon to Tendermint v0.34.24 
+* (consensus) [\#1310](https://github.com/Finschia/finschia-sdk/pull/1310) fix app-hash mismatch if upgrade migration commit is interrupted(backport cosmos/cosmos-sdk#13530)
 
 ### State Machine Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,12 +64,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client) [\#1303](https://github.com/Finschia/finschia-sdk/pull/1303) fix possible overflow in BuildUnsignedTx 
 * (types) [\#1299](https://github.com/Finschia/finschia-sdk/pull/1299) add missing nil checks
 * (x/staking) [\#1301](https://github.com/Finschia/finschia-sdk/pull/1301) Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)
+* (store) [\#1310](https://github.com/Finschia/finschia-sdk/pull/1310) fix app-hash mismatch if upgrade migration commit is interrupted(backport cosmos/cosmos-sdk#13530)
 
 ### Removed
 
 ### Breaking Changes
-* (consensus) [\#1178](https://github.com/Finschia/finschia-sdk/pull/1178) change the consensus from Ostracon to Tendermint v0.34.24 
-* (consensus) [\#1310](https://github.com/Finschia/finschia-sdk/pull/1310) fix app-hash mismatch if upgrade migration commit is interrupted(backport cosmos/cosmos-sdk#13530)
+* (consensus) [\#1178](https://github.com/Finschia/finschia-sdk/pull/1178) change the consensus from Ostracon to Tendermint v0.34.24
 
 ### State Machine Breaking
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -984,8 +984,16 @@ func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore
 	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
 
 	for key, store := range storeMap {
-		commitID := store.Commit()
+		last := store.LastCommitID()
 
+		// If a commit event execution is interrupted, a new iavl store's version will be larger than the rootmulti's metadata, when the block is replayed, we should avoid committing that iavl store again.
+		var commitID types.CommitID
+		if last.Version >= version {
+			last.Version = version
+			commitID = last
+		} else {
+			commitID = store.Commit()
+		}
 		if store.GetStoreType() == types.StoreTypeTransient {
 			continue
 		}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -858,3 +858,76 @@ func TestSetIAVLDIsableFastNode(t *testing.T) {
 	multi.SetIAVLDisableFastNode(false)
 	require.Equal(t, multi.iavlDisableFastNode, false)
 }
+
+type commitKVStoreStub struct {
+	types.CommitKVStore
+	Committed int
+}
+
+func (stub *commitKVStoreStub) Commit() types.CommitID {
+	commitID := stub.CommitKVStore.Commit()
+	stub.Committed += 1
+	return commitID
+}
+
+func prepareStoreMap() map[types.StoreKey]types.CommitKVStore {
+	var db dbm.DB = dbm.NewMemDB()
+	store := NewStore(db, log.NewNopLogger())
+	store.MountStoreWithDB(types.NewKVStoreKey("iavl1"), types.StoreTypeIAVL, nil)
+	store.MountStoreWithDB(types.NewKVStoreKey("iavl2"), types.StoreTypeIAVL, nil)
+	store.MountStoreWithDB(types.NewTransientStoreKey("trans1"), types.StoreTypeTransient, nil)
+	store.LoadLatestVersion()
+	return map[types.StoreKey]types.CommitKVStore{
+		testStoreKey1: &commitKVStoreStub{
+			CommitKVStore: store.GetStoreByName("iavl1").(types.CommitKVStore),
+		},
+		testStoreKey2: &commitKVStoreStub{
+			CommitKVStore: store.GetStoreByName("iavl2").(types.CommitKVStore),
+		},
+		testStoreKey3: &commitKVStoreStub{
+			CommitKVStore: store.GetStoreByName("trans1").(types.CommitKVStore),
+		},
+	}
+}
+
+func TestCommitStores(t *testing.T) {
+	testCases := []struct {
+		name          string
+		committed     int
+		exptectCommit int
+	}{
+		{
+			"when upgrade not get interrupted",
+			0,
+			1,
+		},
+		{
+			"when upgrade get interrupted once",
+			1,
+			0,
+		},
+		{
+			"when upgrade get interrupted twice",
+			2,
+			0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storeMap := prepareStoreMap()
+			store := storeMap[testStoreKey1].(*commitKVStoreStub)
+			for i := tc.committed; i > 0; i-- {
+				store.Commit()
+			}
+			store.Committed = 0
+			var version int64 = 1
+			removalMap := map[types.StoreKey]bool{}
+			res := commitStores(version, storeMap, removalMap)
+			for _, s := range res.StoreInfos {
+				require.Equal(t, version, s.CommitId.Version)
+			}
+			require.Equal(t, version, res.Version)
+			require.Equal(t, tc.exptectCommit, store.Committed)
+		})
+	}
+}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -876,7 +876,10 @@ func prepareStoreMap() map[types.StoreKey]types.CommitKVStore {
 	store.MountStoreWithDB(types.NewKVStoreKey("iavl1"), types.StoreTypeIAVL, nil)
 	store.MountStoreWithDB(types.NewKVStoreKey("iavl2"), types.StoreTypeIAVL, nil)
 	store.MountStoreWithDB(types.NewTransientStoreKey("trans1"), types.StoreTypeTransient, nil)
-	store.LoadLatestVersion()
+	err := store.LoadLatestVersion()
+	if err != nil {
+		panic(err)
+	}
 	return map[types.StoreKey]types.CommitKVStore{
 		testStoreKey1: &commitKVStoreStub{
 			CommitKVStore: store.GetStoreByName("iavl1").(types.CommitKVStore),

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -921,8 +921,7 @@ func TestCommitStores(t *testing.T) {
 			}
 			store.Committed = 0
 			var version int64 = 1
-			removalMap := map[types.StoreKey]bool{}
-			res := commitStores(version, storeMap, removalMap)
+			res := commitStores(version, storeMap)
 			for _, s := range res.StoreInfos {
 				require.Equal(t, version, s.CommitId.Version)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* (audit issue) app-hash mismatch if upgrade migration commit is interrupted
  * backport: cosmos/cosmos-sdk#13530

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
