### PR TITLE
fix: ignore error when key not found in keys delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking) [\#1301](https://github.com/Finschia/finschia-sdk/pull/1301) Use bytes instead of string comparison in delete validator queue (backport cosmos/cosmos-sdk#12303)
 * (x/gov) [\#1304](https://github.com/Finschia/finschia-sdk/pull/1304) fetch a failed proposal tally from proposal.FinalTallyResult in the gprc query
 * (x/staking) [\#1306](https://github.com/Finschia/finschia-sdk/pull/1306) add validation for potential slashing evasion during re-delegation
+* (client/keys) [#1312](https://github.com/Finschia/finschia-sdk/pull/1312) ignore error when key not found in `keys delete`
 
 ### Removed
 

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -37,7 +37,8 @@ private keys stored in a ledger device cannot be deleted with the CLI.
 			for _, name := range args {
 				info, err := clientCtx.Keyring.Key(name)
 				if err != nil {
-					return err
+					cmd.PrintErrf("key %s not found\n", name)
+					continue
 				}
 
 				// confirm deletion, unless -y is passed

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -51,8 +51,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
 	err = cmd.ExecuteContext(ctx)
-	require.Error(t, err)
-	require.EqualError(t, err, "blah.info: key not found")
+	require.NoError(t, err)
 
 	// User confirmation missing
 	cmd.SetArgs([]string{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you provide a list of keys to the keys delete command, it will stop and fail if one of those keys is not found.

This pr cherry-pick the following pr:
- https://github.com/cosmos/cosmos-sdk/pull/18562

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
