### PR TITLE
fix(server): properly parse multiple gas config(backport cosmos/cosmos-sdk#18537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/crypto) [\#1316](https://github.com/Finschia/finschia-sdk/pull/1316) error if incorrect ledger public key (backport cosmos/cosmos-sdk#14460, cosmos/cosmos-sdk#19691) 
 * (x/auth) [#1319](https://github.com/Finschia/finschia-sdk/pull/1319) prevent signing from wrong key in multisig
 * (x/mint, x/slashing) [\#1323](https://github.com/Finschia/finschia-sdk/pull/1323) add missing nil check for params validation
-* (x/server) fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter (backport cosmos/cosmos-sdk#18537)
+* (x/server) [\#1337](https://github.com/Finschia/finschia-sdk/pull/1337) fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter (backport cosmos/cosmos-sdk#18537)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/crypto) [\#1316](https://github.com/Finschia/finschia-sdk/pull/1316) error if incorrect ledger public key (backport cosmos/cosmos-sdk#14460, cosmos/cosmos-sdk#19691) 
 * (x/auth) [#1319](https://github.com/Finschia/finschia-sdk/pull/1319) prevent signing from wrong key in multisig
 * (x/mint, x/slashing) [\#1323](https://github.com/Finschia/finschia-sdk/pull/1323) add missing nil check for params validation
+* (x/server) fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter (backport cosmos/cosmos-sdk#18537)
 
 ### Removed
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/spf13/viper"
 
@@ -207,23 +206,15 @@ func (c *Config) SetMinGasPrices(gasPrices sdk.DecCoins) {
 	c.MinGasPrices = gasPrices.String()
 }
 
-// GetMinGasPrices returns the validator's minimum gas prices based on the set
-// configuration.
+// GetMinGasPrices returns the validator's minimum gas prices based on the set configuration.
 func (c *Config) GetMinGasPrices() sdk.DecCoins {
 	if c.MinGasPrices == "" {
 		return sdk.DecCoins{}
 	}
 
-	gasPricesStr := strings.Split(c.MinGasPrices, ";")
-	gasPrices := make(sdk.DecCoins, len(gasPricesStr))
-
-	for i, s := range gasPricesStr {
-		gasPrice, err := sdk.ParseDecCoin(s)
-		if err != nil {
-			panic(fmt.Errorf("failed to parse minimum gas price coin (%s): %s", s, err))
-		}
-
-		gasPrices[i] = gasPrice
+	gasPrices, err := sdk.ParseDecCoins(c.MinGasPrices)
+	if err != nil {
+		panic(fmt.Sprintf("invalid minimum gas prices: %v", err))
 	}
 
 	return gasPrices

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -14,10 +14,18 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, cfg.GetMinGasPrices().IsZero())
 }
 
-func TestSetMinimumFees(t *testing.T) {
+func TestGetAndSetMinimumGas(t *testing.T) {
 	cfg := DefaultConfig()
-	cfg.SetMinGasPrices(sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)})
+
+	input := sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)}
+	cfg.SetMinGasPrices(input)
 	require.Equal(t, "5.000000000000000000foo", cfg.MinGasPrices)
+	require.EqualValues(t, cfg.GetMinGasPrices(), input)
+
+	input = sdk.DecCoins{sdk.NewInt64DecCoin("bar", 1), sdk.NewInt64DecCoin("foo", 5)}
+	cfg.SetMinGasPrices(input)
+	require.Equal(t, "1.000000000000000000bar,5.000000000000000000foo", cfg.MinGasPrices)
+	require.EqualValues(t, cfg.GetMinGasPrices(), input)
 }
 
 func TestValidateBasic(t *testing.T) {

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -17,7 +17,7 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 
 # The minimum gas prices a validator is willing to accept for processing a
 # transaction. A transaction's fees must meet the minimum of any denomination
-# specified in this config (e.g. 0.25token1;0.0001token2).
+# specified in this config (e.g. 0.25token1,0.0001token2).
 minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 
 # default: the last 100 states are kept in addition to every 500th state; pruning at 10 block intervals


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* fix for multiple gas parsing
  * cosmos/cosmos-sdk#18537

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
