### PR TITLE
fix: update swap keys for possibly overlapped keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/mint, x/slashing) [\#1323](https://github.com/Finschia/finschia-sdk/pull/1323) add missing nil check for params validation
 * (x/server) [\#1337](https://github.com/Finschia/finschia-sdk/pull/1337) fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter (backport cosmos/cosmos-sdk#18537)
 * (x/fbridge) [\#1361](https://github.com/Finschia/finschia-sdk/pull/1361) Fixes fbridge auth checking bug
+* (x/fswap) [\#1365](https://github.com/Finschia/finschia-sdk/pull/1365) fix update swap keys for possibly overlapped keys(`(hello,world) should be different to (hel,loworld)`)
 
 ### Removed
 

--- a/x/fswap/keeper/grpc_query.go
+++ b/x/fswap/keeper/grpc_query.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Finschia/finschia-sdk/store/prefix"
 	sdk "github.com/Finschia/finschia-sdk/types"
+	sdkerrors "github.com/Finschia/finschia-sdk/types/errors"
 	"github.com/Finschia/finschia-sdk/types/query"
 	"github.com/Finschia/finschia-sdk/x/fswap/types"
 )
@@ -23,6 +24,12 @@ func NewQueryServer(keeper Keeper) *QueryServer {
 
 func (s QueryServer) Swapped(ctx context.Context, req *types.QuerySwappedRequest) (*types.QuerySwappedResponse, error) {
 	c := sdk.UnwrapSDKContext(ctx)
+	if err := sdk.ValidateDenom(req.GetFromDenom()); err != nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	}
+	if err := sdk.ValidateDenom(req.GetToDenom()); err != nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	}
 
 	swapped, err := s.Keeper.getSwapped(c, req.GetFromDenom(), req.GetToDenom())
 	if err != nil {
@@ -37,6 +44,12 @@ func (s QueryServer) Swapped(ctx context.Context, req *types.QuerySwappedRequest
 
 func (s QueryServer) TotalSwappableToCoinAmount(ctx context.Context, req *types.QueryTotalSwappableToCoinAmountRequest) (*types.QueryTotalSwappableToCoinAmountResponse, error) {
 	c := sdk.UnwrapSDKContext(ctx)
+	if err := sdk.ValidateDenom(req.GetFromDenom()); err != nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	}
+	if err := sdk.ValidateDenom(req.GetToDenom()); err != nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
+	}
 
 	amount, err := s.Keeper.getSwappableNewCoinAmount(c, req.GetFromDenom(), req.GetToDenom())
 	if err != nil {

--- a/x/fswap/keeper/keys.go
+++ b/x/fswap/keeper/keys.go
@@ -8,12 +8,29 @@ var (
 
 // swapKey key(prefix + fromDenom + toDenom)
 func swapKey(fromDenom, toDenom string) []byte {
-	key := append(swapPrefix, fromDenom...)
-	return append(key, toDenom...)
+	denoms := combineDenoms(fromDenom, toDenom)
+	return append(swapPrefix, denoms...)
 }
 
-// swappedKey key(prefix + fromDenom + toDenom)
+// swappedKey key(prefix + (lengthPrefixed+)fromDenom + (lengthPrefixed+)toDenom)
 func swappedKey(fromDenom, toDenom string) []byte {
-	key := append(swappedKeyPrefix, fromDenom...)
-	return append(key, toDenom...)
+	denoms := combineDenoms(fromDenom, toDenom)
+	return append(swappedKeyPrefix, denoms...)
+}
+
+func combineDenoms(fromDenom, toDenom string) []byte {
+	lengthPrefixedFromDenom := lengthPrefix([]byte(fromDenom))
+	lengthPrefixedToDenom := lengthPrefix([]byte(toDenom))
+	return append(lengthPrefixedFromDenom, lengthPrefixedToDenom...)
+}
+
+// lengthPrefix prefixes the address bytes with its length, this is used
+// for example for variable-length components in store keys.
+func lengthPrefix(bz []byte) []byte {
+	bzLen := len(bz)
+	if bzLen == 0 {
+		return bz
+	}
+
+	return append([]byte{byte(bzLen)}, bz...)
 }

--- a/x/fswap/keeper/keys.go
+++ b/x/fswap/keeper/keys.go
@@ -1,10 +1,5 @@
 package keeper
 
-import (
-	"github.com/Finschia/finschia-sdk/types/address"
-	sdkerrors "github.com/Finschia/finschia-sdk/types/errors"
-)
-
 var (
 	swapPrefix       = []byte{0x01}
 	swapStatsKey     = []byte{0x02}
@@ -24,13 +19,18 @@ func swappedKey(fromDenom, toDenom string) []byte {
 }
 
 func combineDenoms(fromDenom, toDenom string) []byte {
-	lengthPrefixedFromDenom, err := address.LengthPrefix([]byte(fromDenom))
-	if err != nil {
-		panic(sdkerrors.ErrInvalidRequest.Wrapf("fromDenom length should be max %d bytes, got %d", address.MaxAddrLen, len(fromDenom)))
-	}
-	lengthPrefixedToDenom, err := address.LengthPrefix([]byte(toDenom))
-	if err != nil {
-		panic(sdkerrors.ErrInvalidRequest.Wrapf("toDenom length should be max %d bytes, got %d", address.MaxAddrLen, len(toDenom)))
-	}
+	lengthPrefixedFromDenom := lengthPrefix([]byte(fromDenom))
+	lengthPrefixedToDenom := lengthPrefix([]byte(toDenom))
 	return append(lengthPrefixedFromDenom, lengthPrefixedToDenom...)
+}
+
+// lengthPrefix prefixes the address bytes with its length, this is used
+// for example for variable-length components in store keys.
+func lengthPrefix(bz []byte) []byte {
+	bzLen := len(bz)
+	if bzLen == 0 {
+		return bz
+	}
+
+	return append([]byte{byte(bzLen)}, bz...)
 }

--- a/x/fswap/keeper/keys.go
+++ b/x/fswap/keeper/keys.go
@@ -1,5 +1,10 @@
 package keeper
 
+import (
+	"github.com/Finschia/finschia-sdk/types/address"
+	sdkerrors "github.com/Finschia/finschia-sdk/types/errors"
+)
+
 var (
 	swapPrefix       = []byte{0x01}
 	swapStatsKey     = []byte{0x02}
@@ -19,18 +24,13 @@ func swappedKey(fromDenom, toDenom string) []byte {
 }
 
 func combineDenoms(fromDenom, toDenom string) []byte {
-	lengthPrefixedFromDenom := lengthPrefix([]byte(fromDenom))
-	lengthPrefixedToDenom := lengthPrefix([]byte(toDenom))
-	return append(lengthPrefixedFromDenom, lengthPrefixedToDenom...)
-}
-
-// lengthPrefix prefixes the address bytes with its length, this is used
-// for example for variable-length components in store keys.
-func lengthPrefix(bz []byte) []byte {
-	bzLen := len(bz)
-	if bzLen == 0 {
-		return bz
+	lengthPrefixedFromDenom, err := address.LengthPrefix([]byte(fromDenom))
+	if err != nil {
+		panic(sdkerrors.ErrInvalidRequest.Wrapf("fromDenom length should be max %d bytes, got %d", address.MaxAddrLen, len(fromDenom)))
 	}
-
-	return append([]byte{byte(bzLen)}, bz...)
+	lengthPrefixedToDenom, err := address.LengthPrefix([]byte(toDenom))
+	if err != nil {
+		panic(sdkerrors.ErrInvalidRequest.Wrapf("toDenom length should be max %d bytes, got %d", address.MaxAddrLen, len(toDenom)))
+	}
+	return append(lengthPrefixedFromDenom, lengthPrefixedToDenom...)
 }

--- a/x/fswap/keeper/keys_test.go
+++ b/x/fswap/keeper/keys_test.go
@@ -1,0 +1,53 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwapKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromDenom   string
+		toDenom     string
+		expectedKey []byte
+	}{
+		{
+			name:        "swapKey",
+			fromDenom:   "cony",
+			toDenom:     "peb",
+			expectedKey: []byte{0x1, 0x4, 0x63, 0x6f, 0x6e, 0x79, 0x3, 0x70, 0x65, 0x62},
+			//expectedKey: append(swapPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualKey := swapKey(tc.fromDenom, tc.toDenom)
+			require.Equal(t, tc.expectedKey, actualKey)
+		})
+	}
+}
+
+func TestSwappedKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromDenom   string
+		toDenom     string
+		expectedKey []byte
+	}{
+		{
+			name:        "swappedKey",
+			fromDenom:   "cony",
+			toDenom:     "peb",
+			expectedKey: []byte{0x3, 0x4, 0x63, 0x6f, 0x6e, 0x79, 0x3, 0x70, 0x65, 0x62},
+			//expectedKey: append(swappedKeyPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualKey := swappedKey(tc.fromDenom, tc.toDenom)
+			require.Equal(t, tc.expectedKey, actualKey)
+		})
+	}
+}

--- a/x/fswap/keeper/keys_test.go
+++ b/x/fswap/keeper/keys_test.go
@@ -18,7 +18,7 @@ func TestSwapKey(t *testing.T) {
 			fromDenom:   "cony",
 			toDenom:     "peb",
 			expectedKey: []byte{0x1, 0x4, 0x63, 0x6f, 0x6e, 0x79, 0x3, 0x70, 0x65, 0x62},
-			//expectedKey: append(swapPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
+			// expectedKey: append(swapPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
 		},
 	}
 	for _, tc := range tests {
@@ -41,7 +41,7 @@ func TestSwappedKey(t *testing.T) {
 			fromDenom:   "cony",
 			toDenom:     "peb",
 			expectedKey: []byte{0x3, 0x4, 0x63, 0x6f, 0x6e, 0x79, 0x3, 0x70, 0x65, 0x62},
-			//expectedKey: append(swappedKeyPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
+			// expectedKey: append(swappedKeyPrefix, append(append([]byte{byte(len("cony"))}, []byte("cony")...), append([]byte{byte(len("peb"))}, []byte("peb")...)...)...),
 		},
 	}
 	for _, tc := range tests {

--- a/x/fswap/types/fswap.go
+++ b/x/fswap/types/fswap.go
@@ -9,21 +9,26 @@ import (
 
 // ValidateBasic validates the set of Swap
 func (s *Swap) ValidateBasic() error {
-	if s.FromDenom == "" {
-		return sdkerrors.ErrInvalidRequest.Wrap("from denomination cannot be empty")
+	if err := sdk.ValidateDenom(s.FromDenom); err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
-	if s.ToDenom == "" {
-		return sdkerrors.ErrInvalidRequest.Wrap("to denomination cannot be empty")
+
+	if err := sdk.ValidateDenom(s.ToDenom); err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+
 	if s.FromDenom == s.ToDenom {
 		return sdkerrors.ErrInvalidRequest.Wrap("from denomination cannot be equal to to denomination")
 	}
+
 	if s.AmountCapForToDenom.LT(sdk.OneInt()) {
 		return sdkerrors.ErrInvalidRequest.Wrap("amount cannot be less than one")
 	}
+
 	if s.SwapRate.IsZero() {
 		return sdkerrors.ErrInvalidRequest.Wrap("swap rate cannot be zero")
 	}
+
 	return nil
 }
 

--- a/x/fswap/types/msgs.go
+++ b/x/fswap/types/msgs.go
@@ -23,8 +23,8 @@ func (m *MsgSwap) ValidateBasic() error {
 		return sdkerrors.ErrInvalidCoins.Wrap(m.FromCoinAmount.String())
 	}
 
-	if len(m.GetToDenom()) == 0 {
-		return sdkerrors.ErrInvalidRequest.Wrap("invalid denom (empty denom)")
+	if err := sdk.ValidateDenom(m.GetToDenom()); err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
 
 	return nil
@@ -53,12 +53,12 @@ func (m *MsgSwapAll) ValidateBasic() error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("Invalid address (%s)", err)
 	}
 
-	if len(m.GetFromDenom()) == 0 {
-		return sdkerrors.ErrInvalidRequest.Wrap("invalid denom (empty denom)")
+	if err := sdk.ValidateDenom(m.FromDenom); err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
 
-	if len(m.GetToDenom()) == 0 {
-		return sdkerrors.ErrInvalidRequest.Wrap("invalid denom (empty denom)")
+	if err := sdk.ValidateDenom(m.ToDenom); err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* fix: update swap keys for possibly overlapped keys
  * They should be the same -> `(hello, world)` != `(hell, oworld)`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
